### PR TITLE
ML Task Manager: Add "Fetch ML results" functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 Machine Learning-assisted web app for processing Zooniverse Subjects.
 
+## Dev Notes
+
+This project is still a Work In Progress, so the following notes are for
+Zooniverse team devs.
+- The primary feature component is the ML Task Manager (`#/tasks`)
+- As of 2019.07.24, you first need to set the URL of the ML service via the App
+  Config (`#/config`). This was set up to prevent having to store the URL as
+  part of the config.
+- If XHR requests to the ML service API server are receiving CORS errors (e.g.
+  `Access to XMLHttpRequest at 'X' from origin 'Y' has been blocked by CORS policy`),
+  it's due to your web browser's security settings _and_ the server's security
+  policy not playing nice. Two options:
+  - Contact the owners of the API server and request that they update their
+    security policy be updated to allow requests from your host. (Probably
+    `localhost` or `*.zooniverse.org`)
+  - Disable _(temporarily)_ your web browser's security systems. For example,
+    for Chrome on Mac OSX, run `open -a Google\ Chrome --args --disable-web-security --user-data-dir`
+    from bash.
+
 ## Usage
 
 Intended Users:

--- a/src/components/MLTaskManager.js
+++ b/src/components/MLTaskManager.js
@@ -30,7 +30,11 @@ class MLTaskManager extends React.Component {
         <fieldset>
           <legend>ML Task Request ID</legend>
           <div className="flex-row">
-            <input className="text input flex-item grow" value={mlTask.id} onChange={(e) => { mlTask.setId(e.target.value) }} />
+            <input
+              className="text input flex-item grow"
+              value={mlTask.id}
+              onChange={(e) => { mlTask.setId(e.target.value) }}
+            />
             <button
               className="action button flex-item"
               onClick={(e) => {

--- a/src/components/MLTaskManager.js
+++ b/src/components/MLTaskManager.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { observer } from 'mobx-react'
 import AppContext from '@store'
+import { stopEvent } from '@util'
 
 class MLTaskManager extends React.Component {
   constructor (props) {
@@ -29,7 +30,15 @@ class MLTaskManager extends React.Component {
           <legend>ML Task Request ID</legend>
           <div className="flex-row">
             <input className="text input flex-item grow" value={mlTask.id} onChange={(e) => { mlTask.setId(e.target.value) }} />
-            <button className="action button flex-item" onClick={() => { mlTask.fetchTask() }}>Fetch</button>
+            <button
+              className="action button flex-item"
+              onClick={(e) => {
+                mlTask.fetch()
+                stopEvent(e)
+              }}
+            >
+              Fetch
+            </button>
           </div>
         </fieldset>
         

--- a/src/components/MLTaskManager.js
+++ b/src/components/MLTaskManager.js
@@ -5,10 +5,6 @@ import AppContext from '@store'
 class MLTaskManager extends React.Component {
   constructor (props) {
     super(props)
-    
-    this.state = {
-      url: 'https://www.zooniverse.org/api/projects?http_cache=true&page=1&sort=-launch_date&launch_approved=true&cards=true&include=avatar&state=live'
-    }
   }
   
   render () {
@@ -30,10 +26,10 @@ class MLTaskManager extends React.Component {
         </fieldset>
         
         <fieldset>
-          <legend>URL</legend>
+          <legend>ML Task Request ID</legend>
           <div className="flex-row">
-            <input className="text input flex-item grow" value={state.url} onChange={(e) => { this.setState({ url: e.target.value }) }} />
-            <button className="action button flex-item" onClick={() => { mlTask.testFetch(state.url) }}>Fetch</button>
+            <input className="text input flex-item grow" value={mlTask.id} onChange={(e) => { mlTask.setId(e.target.value) }} />
+            <button className="action button flex-item" onClick={() => { mlTask.fetchTask() }}>Fetch</button>
           </div>
         </fieldset>
         

--- a/src/components/MLTaskManager.js
+++ b/src/components/MLTaskManager.js
@@ -11,6 +11,7 @@ class MLTaskManager extends React.Component {
   render () {
     const state = this.state
     const mlTask = this.context.mlTask
+    const mlResults = this.context.mlResults
     
     return (
       <form className="mlTaskManager form">
@@ -23,7 +24,7 @@ class MLTaskManager extends React.Component {
         
         <fieldset>
           <legend>Status</legend>
-          <var>{mlTask.status}</var>
+          <var>Task: {mlTask.status} / Results: {mlResults.status}</var>
         </fieldset>
         
         <fieldset>

--- a/src/store/AppStore.js
+++ b/src/store/AppStore.js
@@ -1,10 +1,12 @@
 import { types } from 'mobx-state-tree'
 import { MLTaskStore } from './MLTaskStore'
+import { MLResultsStore } from './MLResultsStore'
 
 const AppStore = types.model('AppStore', {
   
   user: types.optional(types.string, 'Anonymous'),  
-  mlTask: types.optional(MLTaskStore, {})  // We can use {} to set the initial values of a store
+  mlTask: types.optional(MLTaskStore, {}),  // We can use {} to set the initial values of a store
+  mlResults: types.optional(MLResultsStore, {}),
   
 }).actions(self => {
   return {

--- a/src/store/MLResultsStore.js
+++ b/src/store/MLResultsStore.js
@@ -1,0 +1,53 @@
+import { types } from 'mobx-state-tree'
+import { ASYNC_STATES } from '@util'
+import config from '@config'
+import superagent from 'superagent'
+
+const MLResultsStore = types.model('MLResultsStore', {
+  
+  status: types.optional(types.string, ASYNC_STATES.IDLE),
+  data: types.optional(types.frozen({}), {}),
+  
+}).actions(self => {
+  return {
+    
+    setStatus (val) {
+      self.status = val
+    },
+    
+    setData (val) {
+      self.data = val
+    },
+    
+    fetch (url) {
+      self.setStatus(ASYNC_STATES.FETCHING)
+      
+      superagent
+        .get(url)
+      
+        .withCredentials()
+      
+        .then(res => {
+          if (res.ok) return JSON.parse(res.text)
+          throw new Error('ERROR: ML Results Store can\'t fetch() data')
+        })
+      
+        .then(data => {
+          self.setStatus(ASYNC_STATES.SUCCESS)
+          self.setData(data)
+          
+          console.log('+++ Data From ML Results: ', data)
+          
+          // TODO
+        })
+        
+        .catch(err => {
+          self.setStatus(ASYNC_STATES.ERROR)
+          console.error('[MLResultsStore] ', err)
+        })
+    },
+    
+  }
+})
+
+export { MLResultsStore }

--- a/src/store/MLResultsStore.js
+++ b/src/store/MLResultsStore.js
@@ -6,7 +6,7 @@ import superagent from 'superagent'
 const MLResultsStore = types.model('MLResultsStore', {
   
   status: types.optional(types.string, ASYNC_STATES.IDLE),
-  data: types.optional(types.frozen({}), {}),
+  data: types.frozen({}),
   
 }).actions(self => {
   return {

--- a/src/store/MLResultsStore.js
+++ b/src/store/MLResultsStore.js
@@ -11,6 +11,11 @@ const MLResultsStore = types.model('MLResultsStore', {
 }).actions(self => {
   return {
     
+    reset () {
+      self.status = ASYNC_STATES.IDLE
+      self.data = {}
+    },
+    
     setStatus (val) {
       self.status = val
     },
@@ -37,8 +42,6 @@ const MLResultsStore = types.model('MLResultsStore', {
           self.setData(data)
           
           console.log('+++ Data From ML Results: ', data)
-          
-          // TODO
         })
         
         .catch(err => {

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -3,7 +3,7 @@ import { ASYNC_STATES } from '@util'
 import config from '@config'
 import superagent from 'superagent'
 
-const TASKS_ENDPOINT = '/tasks'
+const TASKS_ENDPOINT = '/task'
 
 const MLTaskStore = types.model('MLTaskStore', {
   
@@ -25,7 +25,19 @@ const MLTaskStore = types.model('MLTaskStore', {
     fetchTask () {
       const url = `${config.mlServiceUrl}${TASKS_ENDPOINT}/${self.id}`
       
-      console.log('+++ ', url)
+      self.setStatus(ASYNC_STATES.FETCHING)
+      
+      superagent
+        .get(url)
+      
+        // Zooniverse API
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/vnd.api+json; version=1')
+      
+        .end((err, res) => {
+          self.setStatus(ASYNC_STATES.SUCCESS)
+          console.log(res)
+        })
     },
     
     testFetch (url = 'https://www.zooniverse.org/api/projects') {

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -10,8 +10,9 @@ const MLTaskStore = types.model('MLTaskStore', {
   
   status: types.optional(types.string, ASYNC_STATES.IDLE),
   id: types.optional(types.string, localStorage.getItem(TASK_ID_STORAGE_KEY) || ''),  // ID of the ML Task, specified by the user.
-  task: types.optional(types.frozen({}), {}),  // Data related to the ML Task itself.
-  results: types.optional(types.array(types.frozen({})), []),  // Data from the results file, which is linked to from the ML Task.
+  data: types.optional(types.frozen({}), {}),  // Data related to the ML Task itself.
+  
+  // Data from the results file, which is linked to from the ML Task, is stored in the MLResultsStore.
   
 }).actions(self => {
   return {
@@ -25,7 +26,11 @@ const MLTaskStore = types.model('MLTaskStore', {
       localStorage.setItem(TASK_ID_STORAGE_KEY, val)
     },
     
-    fetchTask () {
+    setData (val) {
+      self.data = val
+    },
+    
+    fetch () {
       const url = `${config.mlServiceUrl}${TASKS_ENDPOINT}/${self.id}`
       
       self.setStatus(ASYNC_STATES.FETCHING)
@@ -33,12 +38,19 @@ const MLTaskStore = types.model('MLTaskStore', {
       superagent
         .get(url)
       
-        .set('Content-Type', 'application/json')
         .withCredentials()
       
         .then(res => {
-          self.setStatus(ASYNC_STATES.SUCCESS)
-          console.log('+++ res', res)
+          if (res.ok) {
+            self.setStatus(ASYNC_STATES.SUCCESS)
+            return res.body
+          }
+        
+          throw new Error('ERROR: ML Task Store can\'t fetch() data')
+        })
+      
+        .then(data => {
+          self.setData(data)
         })
         
         .catch(err => {

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -30,31 +30,19 @@ const MLTaskStore = types.model('MLTaskStore', {
       superagent
         .get(url)
       
-        // Zooniverse API
         .set('Content-Type', 'application/json')
-        .set('Accept', 'application/vnd.api+json; version=1')
+        .withCredentials()
       
-        .end((err, res) => {
+        .then(res => {
           self.setStatus(ASYNC_STATES.SUCCESS)
-          console.log(res)
+          console.log('+++ res', res)
+        })
+        
+        .catch(err => {
+          self.setStatus(ASYNC_STATES.ERROR)
+          console.log('+++ err', err)
         })
     },
-    
-    testFetch (url = 'https://www.zooniverse.org/api/projects') {
-      self.setStatus(ASYNC_STATES.FETCHING)
-      
-      superagent
-        .get(url)
-      
-        // Zooniverse API
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/vnd.api+json; version=1')
-      
-        .end((err, res) => {
-          self.setStatus(ASYNC_STATES.SUCCESS)
-          console.log(res)
-        })
-    }
     
   }
 })

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -1,4 +1,4 @@
-import { types } from 'mobx-state-tree'
+import { types, getRoot } from 'mobx-state-tree'
 import { ASYNC_STATES } from '@util'
 import config from '@config'
 import superagent from 'superagent'
@@ -50,6 +50,11 @@ const MLTaskStore = types.model('MLTaskStore', {
         })
       
         .then(data => {
+          const root = getRoot(self)
+          
+          console.log('+++ data', data)
+          console.log('+++ root', root)
+        
           self.setData(data)
         })
         

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -17,6 +17,14 @@ const MLTaskStore = types.model('MLTaskStore', {
 }).actions(self => {
   return {
     
+    reset () {
+      self.status = ASYNC_STATES.IDLE
+      self.data = {}
+      
+      const root = getRoot(self)
+      root.mlResults.reset()
+    },
+    
     setStatus (val) {
       self.status = val
     },
@@ -31,9 +39,10 @@ const MLTaskStore = types.model('MLTaskStore', {
     },
     
     fetch () {
-      const url = `${config.mlServiceUrl}${TASKS_ENDPOINT}/${self.id}`
+      self.reset()
       self.setStatus(ASYNC_STATES.FETCHING)
       
+      const url = `${config.mlServiceUrl}${TASKS_ENDPOINT}/${self.id}`
       superagent
         .get(url)
       

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -1,5 +1,5 @@
 import { types, getRoot } from 'mobx-state-tree'
-import { ASYNC_STATES } from '@util'
+import { ASYNC_STATES, API_RESPONSE } from '@util'
 import config from '@config'
 import superagent from 'superagent'
 
@@ -32,7 +32,6 @@ const MLTaskStore = types.model('MLTaskStore', {
     
     fetch () {
       const url = `${config.mlServiceUrl}${TASKS_ENDPOINT}/${self.id}`
-      
       self.setStatus(ASYNC_STATES.FETCHING)
       
       superagent
@@ -41,26 +40,41 @@ const MLTaskStore = types.model('MLTaskStore', {
         .withCredentials()
       
         .then(res => {
-          if (res.ok) {
-            self.setStatus(ASYNC_STATES.SUCCESS)
-            return res.body
-          }
-        
+          if (res.ok) return res.body
           throw new Error('ERROR: ML Task Store can\'t fetch() data')
         })
       
         .then(data => {
           const root = getRoot(self)
-          
-          console.log('+++ data', data)
-          console.log('+++ root', root)
         
+          self.setStatus(ASYNC_STATES.SUCCESS)
           self.setData(data)
+          
+          if (data.status && typeof(data.status) === 'object') {
+            
+            if (data.status.request_status === API_RESPONSE.REQUEST_STATUS.COMPLETED) {
+              const url = data.status.message && data.status.message.output_file_urls && data.status.message.output_file_urls.detections
+              
+              if (url) {
+                root.mlResults.fetch(url)
+              } else {
+                // TODO
+              }
+              
+            } else {
+              // TODO
+            }
+            
+            console.log(data.status)
+            
+          } else {
+            throw new Error('ERROR: the ML Task could not be found or did not have any valid results.')
+          }
         })
         
         .catch(err => {
           self.setStatus(ASYNC_STATES.ERROR)
-          console.log('+++ err', err)
+          console.error('[MLTaskStore] ', err)
         })
     },
     

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -4,12 +4,14 @@ import config from '@config'
 import superagent from 'superagent'
 
 const TASKS_ENDPOINT = '/task'
+const TASK_ID_STORAGE_KEY = 'mlTaskId'
 
 const MLTaskStore = types.model('MLTaskStore', {
   
   status: types.optional(types.string, ASYNC_STATES.IDLE),
-  id: types.optional(types.string, ''),
-  data: types.optional(types.array(types.frozen({})), []),
+  id: types.optional(types.string, localStorage.getItem(TASK_ID_STORAGE_KEY) || ''),  // ID of the ML Task, specified by the user.
+  task: types.optional(types.frozen({}), {}),  // Data related to the ML Task itself.
+  results: types.optional(types.array(types.frozen({})), []),  // Data from the results file, which is linked to from the ML Task.
   
 }).actions(self => {
   return {
@@ -20,6 +22,7 @@ const MLTaskStore = types.model('MLTaskStore', {
     
     setId (val) {
       self.id = val
+      localStorage.setItem(TASK_ID_STORAGE_KEY, val)
     },
     
     fetchTask () {

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -10,7 +10,7 @@ const MLTaskStore = types.model('MLTaskStore', {
   
   status: types.optional(types.string, ASYNC_STATES.IDLE),
   id: types.optional(types.string, localStorage.getItem(TASK_ID_STORAGE_KEY) || ''),  // ID of the ML Task, specified by the user.
-  data: types.optional(types.frozen({}), {}),  // Data related to the ML Task itself.
+  data: types.frozen({}),  // Data related to the ML Task itself.
   
   // Data from the results file, which is linked to from the ML Task, is stored in the MLResultsStore.
   

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -1,10 +1,14 @@
 import { types } from 'mobx-state-tree'
 import { ASYNC_STATES } from '@util'
+import config from '@config'
 import superagent from 'superagent'
+
+const TASKS_ENDPOINT = '/tasks'
 
 const MLTaskStore = types.model('MLTaskStore', {
   
   status: types.optional(types.string, ASYNC_STATES.IDLE),
+  id: types.optional(types.string, ''),
   data: types.optional(types.array(types.frozen({})), []),
   
 }).actions(self => {
@@ -12,6 +16,16 @@ const MLTaskStore = types.model('MLTaskStore', {
     
     setStatus (val) {
       self.status = val
+    },
+    
+    setId (val) {
+      self.id = val
+    },
+    
+    fetchTask () {
+      const url = `${config.mlServiceUrl}${TASKS_ENDPOINT}/${self.id}`
+      
+      console.log('+++ ', url)
     },
     
     testFetch (url = 'https://www.zooniverse.org/api/projects') {

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -5,3 +5,12 @@ export const ASYNC_STATES = {
   SUCCESS: 'success',
   ERROR: 'error',
 }
+
+export function stopEvent (e) {
+  // var eve = e || window.event
+  e.preventDefault && e.preventDefault()
+  e.stopPropagation && e.stopPropagation()
+  e.returnValue = false
+  e.cancelBubble = true
+  return false
+}

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -6,6 +6,12 @@ export const ASYNC_STATES = {
   ERROR: 'error',
 }
 
+export const API_RESPONSE = {
+  REQUEST_STATUS: {
+    COMPLETED: 'completed',
+  },
+}
+
 export function stopEvent (e) {
   // var eve = e || window.event
   e.preventDefault && e.preventDefault()


### PR DESCRIPTION
## PR Overview

Closes #8 .

This PR adds the ability for the ML Task Manager to fetch results from the ML Service.
- A user must specify a Task ID in the ML Task Manager component (`#/tasks`) and then click 'Fetch'
  - No results are displayed on the UI, but the browser's web console can be inspected to see successful results.
- The Fetch process comes in two steps: fetch the ML task/request, and then fetch the 'results' _file_ specified in the ML task/request.
  - Two new MST stores added: MLTaskStore (which contains details of the ML Task/request in general, essentially meta-metadata) and MLResultsStore (which contains the results data, which is what we'll be displaying to users)
- ⚠️ The fetch functionality hasn't been fully tested for many API-specific failure scenarios (e.g.: ML Task is still being processed, response is in an unexpected format) and only handles general failure scenarios (e.g.: can't reach server)

⚠️ Please look at the README to see how the common CORS fetch request error can be solved. Disabling our web browser's security measures are only a temporary solution, and I'll need to follow up with the ML Server team to discuss the HTTP response `header` updates necessary.

### Status

Ready for review. 👍