### PR TITLE
Add .zooniverse.org to allowed hosts

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,10 @@ module.exports = {
     ],
   },
   devServer: {
+    allowedHosts: [
+      'localhost',
+      '.zooniverse.org'
+    ],
     contentBase: path.join(__dirname, 'app'),
     watchContentBase: true,
     port: 3000


### PR DESCRIPTION
Allow webpack dev server to serve pages from localhost.zooniverse.org.