### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**/.next
+**/build
+**/dist
+**/node_modules
+**/.DS_Store
+docs
+plop
+plopfile.js
+*.log


### PR DESCRIPTION
Ignore `node_modules` (and other dev files) when mounting the local filesystem.

This should fix the node-sass error where it tried to use the MacOS binary.

To test this, remove any existing images with `docker rmi zoo-ml-subject-assistant_dev` then `docker-compose up` to build and run a new dev server on http://localhost:3000.

Once you've built the image, `docker-compose up` will run the server without the build step. Use `docker-compose build` if the npm packages change and you need to rebuild.