### PR TITLE
ML Task Manager: improved Status messages (for errors, etc)

### DIFF
--- a/src/components/MLTaskManager/Fetch.js
+++ b/src/components/MLTaskManager/Fetch.js
@@ -23,6 +23,10 @@ class Fetch extends React.Component {
             ? <var className="error block">[Task] {mlTask.statusMessage}</var>
             : null
           }
+          {(mlResults.statusMessage && mlResults.statusMessage.length > 0)
+            ? <var className="error block">[Results] {mlResults.statusMessage}</var>
+            : null
+          }
         </fieldset>
         
         <fieldset>

--- a/src/components/MLTaskManager/Fetch.js
+++ b/src/components/MLTaskManager/Fetch.js
@@ -18,7 +18,11 @@ class Fetch extends React.Component {
       
         <fieldset>
           <legend>Status</legend>
-          <var>Task: {mlTask.status} / Results: {mlResults.status}</var>
+          <var className="block">Task: {mlTask.status} / Results: {mlResults.status}</var>
+          {(mlTask.statusMessage && mlTask.statusMessage.length > 0)
+            ? <var className="error block">[Task] {mlTask.statusMessage}</var>
+            : null
+          }
         </fieldset>
         
         <fieldset>

--- a/src/components/MLTaskManager/Fetch.js
+++ b/src/components/MLTaskManager/Fetch.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { observer } from 'mobx-react'
 import AppContext from '@store'
-import { stopEvent } from '@util'
+import { ASYNC_STATES, stopEvent } from '@util'
 
 class Fetch extends React.Component {
   constructor (props) {
@@ -18,7 +18,11 @@ class Fetch extends React.Component {
       
         <fieldset>
           <legend>Status</legend>
-          <var className="block">Task: {mlTask.status} / Results: {mlResults.status}</var>
+          <var className="block">
+            Task: {mlTask.status} {statusIcon(mlTask.status)}
+            /
+            Results: {mlResults.status} {statusIcon(mlResults.status)}
+          </var>
           {(mlTask.statusMessage && mlTask.statusMessage.length > 0)
             ? <var className="error block">[Task] {mlTask.statusMessage}</var>
             : null
@@ -49,6 +53,22 @@ class Fetch extends React.Component {
       </form>
     )
   }  
+}
+
+function statusIcon (status) {
+  switch (status) {
+    case ASYNC_STATES.IDLE:
+      return <i className="material-icons">more_horiz</i>
+    case ASYNC_STATES.SUCCESS:
+      return <i className="material-icons">done</i>
+    case ASYNC_STATES.ERROR:
+      return <i className="material-icons">error</i>
+    case ASYNC_STATES.FETCHING:
+    case ASYNC_STATES.SENDING:
+      return <i className="material-icons">sync</i>
+  }
+  
+  return null;
 }
 
 Fetch.contextType = AppContext

--- a/src/store/MLResultsStore.js
+++ b/src/store/MLResultsStore.js
@@ -31,7 +31,7 @@ const MLResultsStore = types.model('MLResultsStore', {
       self.setStatus(ASYNC_STATES.FETCHING)
       
       const _url = (!root.demoMode)
-        ? _url
+        ? url
         : DEMO_URL
       
       superagent

--- a/src/store/MLResultsStore.js
+++ b/src/store/MLResultsStore.js
@@ -8,6 +8,7 @@ const DEMO_URL = `${config.appRootUrl}demo-data/detections.txt`
 const MLResultsStore = types.model('MLResultsStore', {
   
   status: types.optional(types.string, ASYNC_STATES.IDLE),
+  statusMessage: types.maybe(types.string),
   data: types.frozen({}),
   
 }).actions(self => {
@@ -15,11 +16,13 @@ const MLResultsStore = types.model('MLResultsStore', {
     
     reset () {
       self.status = ASYNC_STATES.IDLE
+      self.statusMessage = undefined
       self.data = {}
     },
     
-    setStatus (val) {
-      self.status = val
+    setStatus (status, message = undefined) {
+      self.status = status
+      self.statusMessage = message
     },
     
     setData (val) {
@@ -41,7 +44,7 @@ const MLResultsStore = types.model('MLResultsStore', {
       
         .then(res => {        
           if (res.ok) return JSON.parse(res.text)
-          throw new Error('ERROR: ML Results Store can\'t fetch() data')
+          throw new Error('ML Results Store couldn\'t fetch() data')
         })
       
         .then(data => {
@@ -51,7 +54,8 @@ const MLResultsStore = types.model('MLResultsStore', {
         })
         
         .catch(err => {
-          self.setStatus(ASYNC_STATES.ERROR)
+          const message = err && err.toString() || undefined
+          self.setStatus(ASYNC_STATES.ERROR, message)
           console.error('[MLResultsStore] ', err)
         })
     },

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -63,19 +63,15 @@ const MLTaskStore = types.model('MLTaskStore', {
           self.setStatus(ASYNC_STATES.SUCCESS)
           self.setData(data)
           
-          if (data.status && typeof(data.status) === 'object') {
+          if (data.status && typeof(data.status) === 'object'
+              && data.status.request_status === API_RESPONSE.REQUEST_STATUS.COMPLETED) {
             
-            if (data.status.request_status === API_RESPONSE.REQUEST_STATUS.COMPLETED) {
-              const url = data.status.message && data.status.message.output_file_urls && data.status.message.output_file_urls.detections
-              
-              if (url) {
-                root.mlResults.fetch(url)
-              } else {
-                // TODO
-              }
-              
+            const url = data.status.message && data.status.message.output_file_urls && data.status.message.output_file_urls.detections
+
+            if (url) {
+              root.mlResults.fetch(url)
             } else {
-              // TODO
+              throw new Error('ERROR: the ML Task could not be found or did not have any valid results.')
             }
             
           } else {

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -21,6 +21,7 @@ const MLTaskStore = types.model('MLTaskStore', {
     
     reset () {
       self.status = ASYNC_STATES.IDLE
+      self.statusMessage = undefined
       self.data = {}
       
       const root = getRoot(self)

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -10,6 +10,7 @@ const DEMO_URL = `${config.appRootUrl}demo-data/task.txt`
 const MLTaskStore = types.model('MLTaskStore', {
   
   status: types.optional(types.string, ASYNC_STATES.IDLE),
+  statusMessage: types.maybe(types.string),
   id: types.optional(types.string, localStorage.getItem(TASK_ID_STORAGE_KEY) || ''),  // ID of the ML Task, specified by the user.
   data: types.frozen({}),  // Data related to the ML Task itself.
   
@@ -26,8 +27,13 @@ const MLTaskStore = types.model('MLTaskStore', {
       root.mlResults.reset()
     },
     
-    setStatus (val) {
-      self.status = val
+    setStatus (status, message = undefined) {
+      self.status = status
+      self.statusMessage = message
+    },
+    
+    setStatusMessage (val) {
+      self.statusMessage = val
     },
     
     setId (val) {
@@ -56,7 +62,7 @@ const MLTaskStore = types.model('MLTaskStore', {
       
         .then(res => {
           if (res.ok) return res.body || JSON.parse(res.text)  // The latter is for demo-data
-          throw new Error('ERROR: ML Task Store can\'t fetch() data')
+          throw new Error('ML Task Store can\'t fetch() data')
         })
       
         .then(data => {
@@ -71,16 +77,17 @@ const MLTaskStore = types.model('MLTaskStore', {
             if (url) {
               root.mlResults.fetch(url)
             } else {
-              throw new Error('ERROR: the ML Task could not be found or did not have any valid results.')
+              throw new Error('the ML Task could not be found or did not have any valid results.')
             }
             
           } else {
-            throw new Error('ERROR: the ML Task could not be found or did not have any valid results.')
+            throw new Error('the ML Task could not be found or did not have any valid results.')
           }
         })
         
         .catch(err => {
-          self.setStatus(ASYNC_STATES.ERROR)
+          const message = err && err.toString() || undefined
+          self.setStatus(ASYNC_STATES.ERROR, message)
           console.error('[MLTaskStore] ', err)
         })
     },

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -11,6 +11,10 @@
   
   fieldset {
     margin: 0.5em;
+    
+    var .material-icons {
+      vertical-align: bottom;
+    }
   }
   
   .panel {

--- a/src/styles/_layouts.scss
+++ b/src/styles/_layouts.scss
@@ -1,3 +1,11 @@
+.block {
+  display: block;
+}
+
+.error {
+  color: $danger-colour;
+}
+
 .flex-row {
   display: flex;
   flex-direction: row;

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -7,8 +7,13 @@ export const ASYNC_STATES = {
 }
 
 export const API_RESPONSE = {
+  STATUS: {
+    NOT_FOUND: 'n',
+  },
   REQUEST_STATUS: {
     COMPLETED: 'completed',
+    RUNNING: 'running',
+    FAILED: 'failed',
   },
 }
 


### PR DESCRIPTION
## PR Overview

This PR updates the MLTaskManager so that it's better able to handle various failure states.
- When the Task's or Results's `fetch()` action fails, the error message is more informative.
  - Known failure states are as follows:
    - Task could not be found (e.g. invalid Task ID)
    - Task is still running (being processed on the ML Service)
    - Task could not be processed (error due to faulty data, for example)
    - Could not reach ML Service to retrieve Task
    - Could not reach Results (detections) file
- Additionally, minor visual improvements are added to the status messages: each state is accompanied by an icon, for starters.

![Screen Shot 2019-08-21 at 15 14 58](https://user-images.githubusercontent.com/13952701/63439939-e4ec3f00-c426-11e9-971e-174b1b95a40a.png)

### Status

Ready for review. Based on #22, and this PR/branch should be retargeted+rebased once that's merged.