### PR TITLE
Proxy server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.2'
 
 services:
   dev:
+    image: ms-ml-dev:latest
     build:
       context: ./
       dockerfile: Dockerfile
@@ -13,5 +14,21 @@ services:
     environment:
       - HOST=0.0.0.0
     volumes:
-      - ${PWD}:/src
-      - /src/node_modules
+      - ${PWD}:/usr/src
+      - /usr/src/node_modules
+  proxy:
+    image: ms-ml-dev:latest
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    entrypoint:
+      - "node"
+    command: ["server/proxy-server.js"]
+    ports:
+      - "3666:3666"
+    environment:
+      - ORIGINS=${ORIGINS}
+      - TARGETS=${TARGETS}
+    volumes:
+      - ${PWD}:/usr/src
+      - /usr/src/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1097,7 +1097,6 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-      "dev": true,
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
@@ -1494,7 +1493,6 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-      "dev": true,
       "requires": {
         "bytes": "3.1.0",
         "content-type": "~1.0.4",
@@ -1511,14 +1509,12 @@
         "bytes": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1526,14 +1522,12 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "qs": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
@@ -2072,7 +2066,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -2080,8 +2073,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -2095,14 +2087,12 @@
     "cookie": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-      "dev": true
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "dev": true
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cookiejar": {
       "version": "2.1.2",
@@ -2402,8 +2392,7 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "des.js": {
       "version": "1.0.0",
@@ -2418,8 +2407,7 @@
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-file": {
       "version": "1.0.0",
@@ -2500,8 +2488,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
       "version": "1.3.191",
@@ -2539,8 +2526,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -2583,8 +2569,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2626,8 +2611,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter3": {
       "version": "3.1.2",
@@ -2753,7 +2737,6 @@
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
       "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-      "dev": true,
       "requires": {
         "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
@@ -2790,14 +2773,12 @@
         "array-flatten": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-          "dev": true
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -2805,20 +2786,17 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "path-to-regexp": {
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-          "dev": true
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
         "qs": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
     },
@@ -2988,7 +2966,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -3003,7 +2980,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -3011,8 +2987,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -3117,8 +3092,7 @@
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-      "dev": true
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3132,8 +3106,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "from2": {
       "version": "2.3.0",
@@ -3183,8 +3156,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3205,14 +3177,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3227,20 +3197,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3357,8 +3324,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3370,7 +3336,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3385,7 +3350,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3393,14 +3357,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3419,7 +3381,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3500,8 +3461,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3513,7 +3473,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3599,8 +3558,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3636,7 +3594,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3656,7 +3613,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3700,14 +3656,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4085,7 +4039,6 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -4097,8 +4050,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
@@ -4152,7 +4104,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -4282,8 +4233,7 @@
     "ipaddr.js": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
-      "dev": true
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -4837,8 +4787,7 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
       "version": "4.3.0",
@@ -4882,8 +4831,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "methods": {
       "version": "1.1.2",
@@ -5142,8 +5090,7 @@
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-      "dev": true
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "neo-async": {
       "version": "2.6.1",
@@ -5438,7 +5385,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -5629,8 +5575,7 @@
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -5913,7 +5858,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
       "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
-      "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.0"
@@ -6035,14 +5979,12 @@
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
       "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-      "dev": true,
       "requires": {
         "bytes": "3.1.0",
         "http-errors": "1.7.2",
@@ -6053,8 +5995,7 @@
         "bytes": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true
+          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
         }
       }
     },
@@ -6470,8 +6411,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -6573,7 +6513,6 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
       "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -6594,7 +6533,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           },
@@ -6602,16 +6540,14 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -6681,7 +6617,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-      "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -6727,8 +6662,7 @@
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-      "dev": true
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -7126,8 +7060,7 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stdout-stream": {
       "version": "1.4.1",
@@ -7457,8 +7390,7 @@
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "dev": true
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
       "version": "2.4.3",
@@ -7530,7 +7462,6 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -7609,8 +7540,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -7738,8 +7668,7 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "dev": true
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.3.2",
@@ -7771,8 +7700,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "start": "webpack-dev-server",
     "clean": "rm -fr ./app",
-    "build": "npm run clean && webpack"
+    "build": "npm run clean && webpack",
+    "proxy-server": "node server/proxy-server.js"
   },
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
   "license": "Apache-2.0",
   "dependencies": {
+    "express": "^4.17.1",
     "json2csv": "^4.5.2",
     "mobx": "^5.11.0",
     "mobx-react": "^6.1.1",

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -4,15 +4,24 @@ const request = require('request')  // Note: superagent doesn't work well in thi
 const server = express()
 
 const config = {
-  origin: process.env.ORIGIN || 'http://local.zooniverse.org:3000',
+  origins: process.env.ORIGINS || 'http://localhost:3000;http://local.zooniverse.org:3000',
   targets: process.env.TARGETS || 'http://example.com;https://www.zooniverse.org/',
   port: process.env.PORT || 3666,
 }
 
 server.use(function (req, res, next) {
-  res.header('Access-Control-Allow-Origin', config.origin)
-  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
-  res.header('Access-Control-Allow-Credentials', 'true')
+  const origin = req.get('origin') || ''
+  const acceptableOrigins = config.origins.split(';')
+  const originIsAcceptable = acceptableOrigins.find(function (target) {
+    return origin.toLowerCase() === target.toLowerCase()
+  })
+  
+  if (originIsAcceptable) {
+    res.header('Access-Control-Allow-Origin', origin)
+    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+    res.header('Access-Control-Allow-Credentials', 'true')
+  }
+  
   next();
 });
 

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -5,7 +5,7 @@ const server = express()
 
 const config = {
   port: 3666,
-  targetServer: 'https://shaunanoordin.com',
+  targetServer: 'https://www.zooniverse.org',
 }
 
 function getQueryString (queryObject) {
@@ -23,9 +23,13 @@ function getQueryString (queryObject) {
 function proxyGet (req, res) {
   const query = getQueryString(req.query)
   const path = req.path
-  
-  //console.log(res)
-  res.send(`Path: ${path}${query}` )
+
+  superagent.get(`${config.targetServer}${path}${query}`)
+  .then(proxyRes => {
+    res
+    .type(proxyRes.type)
+    .send(proxyRes.text)
+  })
 }
 
 server.get('*', proxyGet)

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -28,10 +28,7 @@ function proxyGet (req, res) {
       // Note: proxyBody is the parsed data.
       // proxyRes.body is unparsed.
       
-      console.log('url: ', url)
-      console.log('proxyErr: ', proxyErr)
-      console.log('proxyRes: ', proxyRes)
-      console.log('--------')
+      // TODO: handle errors, etc
     
       res.send(proxyRes.body)
     });

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -18,14 +18,24 @@ server.use(function (req, res, next) {
 
 function proxyGet (req, res) {
   try {
-    const url = req.query.url
+    const url = req.query.url || ''
+    const acceptableTargets = config.targets.split(';')
+    const urlIsAcceptable = acceptableTargets.find(function (target) {
+      return target.toLowerCase().startsWith(url.toLowerCase())
+    })
 
-    if (!url) {
+    if (url.length === 0) {
 
       res
         .status(500)
         .send('No URL specified')
 
+    } else if (!urlIsAcceptable) {
+      
+      res
+        .status(500)
+        .send('Target URL is not in the whitelist')
+      
     } else {
 
       request(url, function (proxyErr, proxyRes, proxyBody) {
@@ -62,4 +72,5 @@ server.listen(config.port, (err) => {
   if (err) throw err
   console.log(`Proxy Server running at port ${config.port}`)
   console.log(`Acceptable origin: ${config.origin}`)
+  console.log(`Acceptable targets: ${config.targets.split(';')}`)
 })

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -47,9 +47,8 @@ function proxyGet (req, res) {
       
     } else {
 
-      request(url, function (proxyErr, proxyRes, proxyBody) {
-        // Note: proxyBody is the parsed data.
-        // proxyRes.body is unparsed.
+      request(url, function (proxyErr, proxyRes) {
+        // Note: proxyRes.body is unparsed data.
         
         let status = (proxyRes && proxyRes.statusCode) || 500
         let statusMessage = (proxyRes && proxyRes.statusMessage) || 'No data'
@@ -80,6 +79,6 @@ server.get('*', proxyGet)
 server.listen(config.port, (err) => {
   if (err) throw err
   console.log(`Proxy Server running at port ${config.port}`)
-  console.log(`Acceptable origin: ${config.origin}`)
+  console.log(`Acceptable origins: ${config.origins.split(';')}`)
   console.log(`Acceptable targets: ${config.targets.split(';')}`)
 })

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -1,1 +1,36 @@
-console.log('Hello Proxy Server')
+const express = require('express')
+const superagent = require('superagent')
+
+const server = express()
+
+const config = {
+  port: 3666,
+  targetServer: 'https://shaunanoordin.com',
+}
+
+function getQueryString (queryObject) {
+  const str = Object
+  .keys(queryObject).map((key) => {
+    const val = encodeURIComponent(queryObject[key])
+    return `${key}=${val}`
+  })
+  .join('&')
+  return (str.length > 0)
+    ? `?${str}`
+    : str
+}
+
+function proxyGet (req, res) {
+  const query = getQueryString(req.query)
+  const path = req.path
+  
+  //console.log(res)
+  res.send(`Path: ${path}${query}` )
+}
+
+server.get('*', proxyGet)
+
+server.listen(config.port, (err) => {
+  if (err) throw err
+  console.log(`Proxy Server running at port ${config.port}`)
+})

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -21,7 +21,7 @@ function proxyGet (req, res) {
     const url = req.query.url || ''
     const acceptableTargets = config.targets.split(';')
     const urlIsAcceptable = acceptableTargets.find(function (target) {
-      return target.toLowerCase().startsWith(url.toLowerCase())
+      return url.toLowerCase().startsWith(target.toLowerCase())
     })
 
     if (url.length === 0) {

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -1,0 +1,1 @@
+console.log('Hello Proxy Server')

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -4,32 +4,26 @@ const superagent = require('superagent')
 const server = express()
 
 const config = {
-  port: 3666,
-  targetServer: 'https://www.zooniverse.org',
-}
-
-function getQueryString (queryObject) {
-  const str = Object
-  .keys(queryObject).map((key) => {
-    const val = encodeURIComponent(queryObject[key])
-    return `${key}=${val}`
-  })
-  .join('&')
-  return (str.length > 0)
-    ? `?${str}`
-    : str
+  port: process.env.PORT || 3666,
 }
 
 function proxyGet (req, res) {
-  const query = getQueryString(req.query)
-  const path = req.path
-
-  superagent.get(`${config.targetServer}${path}${query}`)
-  .then(proxyRes => {
-    res
-    .type(proxyRes.type)
-    .send(proxyRes.text)
-  })
+  const url = req.query.url
+  
+  if (!url) {
+    
+    res.send('No URL specified')
+    
+  } else {
+    
+    superagent.get(url)
+    .then(proxyRes => {
+      res
+      .type(proxyRes.type)
+      .send(proxyRes.text)
+    })
+    
+  }
 }
 
 server.get('*', proxyGet)

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -4,8 +4,16 @@ const superagent = require('superagent')
 const server = express()
 
 const config = {
+  origin: process.env.ORIGIN || 'http://local.zooniverse.org:3000',
   port: process.env.PORT || 3666,
 }
+
+server.use(function (req, res, next) {
+  res.header('Access-Control-Allow-Origin', config.origin)
+  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+  res.header('Access-Control-Allow-Credentials', 'true')
+  next();
+});
 
 function proxyGet (req, res) {
   const url = req.query.url
@@ -31,4 +39,5 @@ server.get('*', proxyGet)
 server.listen(config.port, (err) => {
   if (err) throw err
   console.log(`Proxy Server running at port ${config.port}`)
+  console.log(`Acceptable origin: ${config.origin}`)
 })

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -1,5 +1,5 @@
 const express = require('express')
-const superagent = require('superagent')
+const request = require('request')  // Note: superagent doesn't work well in this scenario.
 
 const server = express()
 
@@ -24,13 +24,17 @@ function proxyGet (req, res) {
     
   } else {
     
-    superagent.get(url)
-    .then(proxyRes => {
-      res
-      .type(proxyRes.type)
-      .send(proxyRes.text)
-    })
+    request(url, function (proxyErr, proxyRes, proxyBody) {
+      // Note: proxyBody is the parsed data.
+      // proxyRes.body is unparsed.
+      
+      console.log('url: ', url)
+      console.log('proxyErr: ', proxyErr)
+      console.log('proxyRes: ', proxyRes)
+      console.log('--------')
     
+      res.send(proxyRes.body)
+    });
   }
 }
 

--- a/src/components/MLTaskManager/ProcessAndOutput.js
+++ b/src/components/MLTaskManager/ProcessAndOutput.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { observer } from 'mobx-react'
 import { parse } from 'json2csv'
-import streamSaver from 'StreamSaver'
+import streamSaver from 'streamsaver'
 
 import AppContext from '@store'
 import { ASYNC_STATES, stopEvent } from '@util'

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ if (!env.match(/^(production|staging|development)$/)) {
 const config = {
   appRootUrl: localStorage.getItem('appRootUrl') || `${window.location.origin}${window.location.pathname}`,
   mlServiceUrl: localStorage.getItem('mlServiceUrl') || 'https://www.zooniverse.org/api',
+  proxyUrl: localStorage.getItem('proxyUrl') || 'http://localhost:3666',
   panoptesAppId: (env === 'production')
     ? ''
     : '5243dacf3a321843b1bca09047edfbac5eb39dba14f1be06a0a54dfe6a098694'

--- a/src/store/MLResultsStore.js
+++ b/src/store/MLResultsStore.js
@@ -24,8 +24,10 @@ const MLResultsStore = types.model('MLResultsStore', {
     self.status = ASYNC_STATES.FETCHING
     self.statusMessage = undefined
 
+    const proxiedUrl = `${config.proxyUrl}?url=${encodeURIComponent(url)}`
+    
     const _url = (!root.demoMode)
-      ? url
+      ? proxiedUrl
       : DEMO_URL
 
     try {

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -89,7 +89,6 @@ const MLTaskStore = types.model('MLTaskStore', {
       const message = err && err.toString() || undefined
       self.status = ASYNC_STATES.ERROR
       self.statusMessage = message
-      self.data = data
       console.error('[MLTaskStore] ', err)
     }
 

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -39,8 +39,11 @@ const MLTaskStore = types.model('MLTaskStore', {
     self.status = ASYNC_STATES.FETCHING
     self.statusMessage = undefined
 
+    const serviceUrl = `${config.mlServiceUrl}${TASKS_ENDPOINT}/${self.id}`
+    const proxiedUrl = `${config.proxyUrl}?url=${encodeURIComponent(serviceUrl)}`
+    
     const url = (!root.demoMode)
-      ? `${config.mlServiceUrl}${TASKS_ENDPOINT}/${self.id}`
+      ? proxiedUrl
       : DEMO_URL
 
     try {


### PR DESCRIPTION
## PR Overview

Closes #24 

This PR creates a proxy server that lets us send requests to the ML Service that bypass the browser's CORS security.
- ❗️ The proxy server _needs to_ be able to live on a Kubernetes server. Once I've got the server code running on localhost, I'll ping Adam for help setting this up on a live server.
- The proxy server does exactly what a proxy does - pass requests to the target ML Service, and responds back with the same response from the ML service.
  - Currently, the proxy can only successfully process text-type content (so, we can't proxy image files, for example)
- Temporary config: the proxy server currently sits at port 3666 and targets, uh, zooniverse.org, but this will be configurable eventually.

The proxy can be run on localhost by running `npm run proxy-server`, and visited by going to `http://localhost:3666`

### Status

WIP