### PR TITLE
Setup Proxy Server for Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-FROM node:8
+FROM node:8 as builder
 
 RUN mkdir -p /usr/src
 WORKDIR /usr/src/
 
-COPY ./ .
+ADD package.json /usr/src/
+ADD package-lock.json /usr/src/
+
 RUN chown -R node:node .
 
 USER node
 
 RUN npm install
+
+COPY ./ .
+
+FROM builder as proxy
+
+EXPOSE 3666
+
+CMD ["node", "server/proxy-server.js"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,65 @@
+#!groovy
+
+// Uses the Jenkins Declarative Pipeline -
+// https://jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline
+
+// ProTip: If you're debugging changes to this file, use the replay feature in
+// Jenkins rather than the commit/watch/fix cycle:
+//   1. Go to https://jenkins.zooniverse.org/job/Zooniverse%20GitHub/job/front-end-monorepo/
+//   2. Find your branch and click on it
+//   3. Pick a build from the list in the sidebar
+//   4. Click 'Replay' in the sidebar
+//   5. You should get an editor where you can modify the pipeline and run it
+//      again immediately <3
+
+pipeline {
+  agent none
+
+  options {
+    quietPeriod(120) // builds happen at least 120 seconds apart
+    disableConcurrentBuilds()
+  }
+
+  stages {
+
+    // Right now, we're *only* building and deploying on the `master` branch;
+    // longer-term, we'll want to deploy feature branches as well.
+    stage('`master` branch') {
+      when { branch 'master' }
+      stages {
+
+        stage('Build base Docker image') {
+          agent any
+          steps {
+            script {
+              def dockerRepoName = 'zooniverse/zoo-ml-subject-assistant'
+              def dockerImageName = "${dockerRepoName}:${GIT_COMMIT}"
+              def newImage = docker.build(dockerImageName)
+              newImage.push()
+              newImage.push('latest')
+            }
+          }
+        }
+
+        stage('Deploy to Kubernetes') {
+          agent any
+          steps {
+            sh "kubectl apply --record -f kubernetes/"
+            sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment.tmpl | kubectl apply --record -f -"
+          }
+        }
+      }
+
+      post {
+        unsuccessful {
+          slackSend (
+            color: '#FF0000',
+            message: "DEPLOY FAILED: Job '${JOB_NAME} [${BUILD_NUMBER}]' (${BUILD_URL})",
+            channel: "#ms-machine-learning"
+          )
+        }
+      }
+    }
+
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3.4'
 
 services:
   dev:
@@ -6,6 +6,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+      target: builder
     entrypoint:
       - "npm"
     command: ["start"]
@@ -20,9 +21,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
-    entrypoint:
-      - "node"
-    command: ["server/proxy-server.js"]
+      target: proxy
     ports:
       - "3666:3666"
     environment:

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: subject-assistant-proxy
+  labels:
+    app: subject-assistant-proxy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: subject-assistant-proxy
+  template:
+    metadata:
+      labels:
+        app: subject-assistant-proxy
+    spec:
+      containers:
+        - name: subject-assistant-proxy-app
+          image: zooniverse/subject-assistant-proxy:__IMAGE_TAG__
+          ports:
+            - containerPort: 80

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
         - name: subject-assistant-proxy-app
-          image: zooniverse/subject-assistant-proxy:__IMAGE_TAG__
+          image: zooniverse/zoo-ml-subject-assistant:__IMAGE_TAG__
           ports:
             - containerPort: 80

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: subject-assistant-proxy
+spec:
+  selector:
+    app: subject-assistant-proxy
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: NodePort

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -8,5 +8,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 3666
   type: NodePort


### PR DESCRIPTION
## PR Overview

This PR prepares the Proxy Server to be deployed on the Kubernetes server (Note 1), which is still, uh, a work in progress.

End goal of this task is that we'll have a proxy server available at, say, `subject-assistant-proxy.zooniverse.org`

### Status

WIP

Note 1: ...as a service called `subject-assistant-proxy`; I suppose we can come back to this decision later if we want the proxy server available for other CFEs.