### PR TITLE
UI Improvements - pre-populated Workflow ID list and Subject Set ID list from user resources

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,6 +8,7 @@ import ConfigForm from './ConfigForm'
 import Home from './Home'
 import Header from './Header'
 import MLTaskManager from './MLTaskManager'
+import Debugger from './Debugger'
 
 import demoDataForTask from '@demo-data/task.txt'
 import demoDataForResults from '@demo-data/detections.txt'
@@ -42,6 +43,7 @@ class App extends React.Component {
                 <Route path="/" exact component={Home} />
                 <Route path="/tasks" component={MLTaskManager} />
                 <Route path="/config" component={ConfigForm} />
+                <Route path="/debug" component={Debugger} />
               </main>
           }
           <footer>Footer</footer>

--- a/src/components/Debugger.js
+++ b/src/components/Debugger.js
@@ -10,9 +10,21 @@ function Debugger () {
     <article className="debugger">
       <h2>Debugger</h2>
       <h3>Owned Projects</h3>
-      {ur.ownedProjects.map((project, index) =>
+      {ur.ownedProjects.map((item, index) =>
         <div key={`user-project-${index}`}>
-          {project.id} / {project.display_name}
+          {item.id} / {item.display_name}
+        </div>
+      )}
+      <h3>Owned Workflows</h3>
+      {ur.ownedWorkflows.map((item, index) =>
+        <div key={`user-workflow-${index}`}>
+          {item.id} / {item.display_name}
+        </div>
+      )}
+      <h3>Owned Subject Sets</h3>
+      {ur.ownedSubjectSets.map((item, index) =>
+        <div key={`user-subjectset-${index}`}>
+          {item.id} / {item.display_name}
         </div>
       )}
     </article>

--- a/src/components/Debugger.js
+++ b/src/components/Debugger.js
@@ -1,0 +1,15 @@
+import React, { useContext } from 'react'
+import { observer } from 'mobx-react'
+
+import AppContext from '@store'
+
+function Debugger () {
+  const store = useContext(AppContext)
+  return (
+    <article className="debugger">
+      <h2>Debugger</h2>
+    </article>
+  )
+}
+
+export default observer(Debugger)

--- a/src/components/Debugger.js
+++ b/src/components/Debugger.js
@@ -5,9 +5,16 @@ import AppContext from '@store'
 
 function Debugger () {
   const store = useContext(AppContext)
+  const ur = store.userResources
   return (
     <article className="debugger">
       <h2>Debugger</h2>
+      <h3>Owned Projects</h3>
+      {ur.ownedProjects.map((project, index) =>
+        <div key={`user-project-${index}`}>
+          {project.id} / {project.display_name}
+        </div>
+      )}
     </article>
   )
 }

--- a/src/components/MLTaskManager/ProcessAndOutput.js
+++ b/src/components/MLTaskManager/ProcessAndOutput.js
@@ -42,23 +42,28 @@ class ProcessAndOutput extends React.Component {
         <fieldset>
           <legend>Move Subjects</legend>
           <div>
-            <span>Select which subject set to move to: &nbsp;</span>
+            <span>Specify which subject set to move to: &nbsp;</span>
+            <input
+              value={workflowOutput.moveTarget}
+              onChange={(e) => { workflowOutput.setMoveTarget(e.target.value) }}
+            />
             {(userResources.status === ASYNC_STATES.SUCCESS && userResources.ownedSubjectSets && userResources.ownedSubjectSets.length > 0)  // If we know which resources the user has, we can show a <select> option. Otherwise, enable manual input.
-              ? <select
-                  value={workflowOutput.moveTarget}
-                  onChange={(e) => { workflowOutput.setMoveTarget(e.target.value) }}
-                >
-                  {userResources.ownedSubjectSets.map(item => (
-                    <option key={`move-to-subjectset-${item.id}`} value={item.id}>
-                      {item.id} - {item.display_name}
-                  </option>
-                  ))}
-                </select>
+              ? <div>
+                  or, choose from: &nbsp;
+                  <select
+                    value={workflowOutput.moveTarget}
+                    onChange={(e) => { workflowOutput.setMoveTarget(e.target.value) }}
+                    class={!(userResources.ownedSubjectSets.map(i=>i.id).includes(workflowOutput.moveTarget)) ? 'greyed-out' : ''}
+                  >
+                    {userResources.ownedSubjectSets.map(item => (
+                      <option key={`move-to-subjectset-${item.id}`} value={item.id}>
+                        {item.id} - {item.display_name}
+                    </option>
+                    ))}
+                  </select>
+                </div>
 
-              : <input
-                  value={workflowOutput.moveTarget}
-                  onChange={(e) => { workflowOutput.setMoveTarget(e.target.value) }}
-                />
+              : null
             }
           </div>
           
@@ -87,23 +92,28 @@ class ProcessAndOutput extends React.Component {
         <fieldset>
           <legend>Retire Subjects</legend>
           <div>
-            <span>Select which workflow to retire from: &nbsp;</span>
-            {(userResources.status === ASYNC_STATES.SUCCESS && userResources.ownedWorkflows && userResources.ownedWorkflows.length > 0)  // If we know which resources the user has, we can show a <select> option. Otherwise, enable manual input.
-              ? <select
-                  value={workflowOutput.retireTarget}
-                  onChange={(e) => { workflowOutput.setRetireTarget(e.target.value) }}
-                >
-                  {userResources.ownedWorkflows.map(item => (
-                    <option key={`retire-from-workflow-${item.id}`} value={item.id}>
-                      {item.id} - {item.display_name}
-                  </option>
-                  ))}
-                </select>
-
-              : <input
-                  value={workflowOutput.retireTarget}
-                  onChange={(e) => { workflowOutput.setRetireTarget(e.target.value) }}
-                />
+            <span>Specify which workflow to retire from: &nbsp;</span>
+            <input
+              value={workflowOutput.retireTarget}
+              onChange={(e) => { workflowOutput.setRetireTarget(e.target.value) }}
+            />
+            
+            {(userResources.status === ASYNC_STATES.SUCCESS && userResources.ownedWorkflows && userResources.ownedWorkflows.length > 0)  // If we know which resources the user has, we can show a <select> option.
+              ? <div>
+                  or, choose from: &nbsp;
+                  <select
+                    value={workflowOutput.retireTarget}
+                    onChange={(e) => { workflowOutput.setRetireTarget(e.target.value) }}
+                    class={!(userResources.ownedWorkflows.map(i=>i.id).includes(workflowOutput.retireTarget)) ? 'greyed-out' : ''}
+                  >
+                    {userResources.ownedWorkflows.map(item => (
+                      <option key={`retire-from-workflow-${item.id}`} value={item.id}>
+                        {item.id} - {item.display_name}
+                    </option>
+                    ))}
+                  </select>
+                </div>
+              : null
             }
           </div>
           

--- a/src/components/MLTaskManager/ProcessAndOutput.js
+++ b/src/components/MLTaskManager/ProcessAndOutput.js
@@ -16,6 +16,7 @@ class ProcessAndOutput extends React.Component {
     const mlResults = this.context.mlResults
     const mlSelection = this.context.mlSelection
     const workflowOutput = this.context.workflowOutput
+    const userResources = this.context.userResources
     
     // If the results aren't ready, don't render this component.
     if (mlTask.status !== ASYNC_STATES.SUCCESS || mlResults.status !== ASYNC_STATES.SUCCESS) {
@@ -42,10 +43,23 @@ class ProcessAndOutput extends React.Component {
           <legend>Move Subjects</legend>
           <div>
             <span>Select which subject set to move to: &nbsp;</span>
-            <input
-              value={workflowOutput.moveTarget}
-              onChange={(e) => { workflowOutput.setMoveTarget(e.target.value) }}
-            />
+            {(userResources.status === ASYNC_STATES.SUCCESS && userResources.ownedSubjectSets && userResources.ownedSubjectSets.length > 0)  // If we know which resources the user has, we can show a <select> option. Otherwise, enable manual input.
+              ? <select
+                  value={workflowOutput.moveTarget}
+                  onChange={(e) => { workflowOutput.setMoveTarget(e.target.value) }}
+                >
+                  {userResources.ownedSubjectSets.map(item => (
+                    <option key={`move-to-subjectset-${item.id}`} value={item.id}>
+                      {item.id} - {item.display_name}
+                  </option>
+                  ))}
+                </select>
+
+              : <input
+                  value={workflowOutput.moveTarget}
+                  onChange={(e) => { workflowOutput.setMoveTarget(e.target.value) }}
+                />
+            }
           </div>
           
           <div>
@@ -74,10 +88,23 @@ class ProcessAndOutput extends React.Component {
           <legend>Retire Subjects</legend>
           <div>
             <span>Select which workflow to retire from: &nbsp;</span>
-            <input
-              value={workflowOutput.retireTarget}
-              onChange={(e) => { workflowOutput.setRetireTarget(e.target.value) }}
-            />
+            {(userResources.status === ASYNC_STATES.SUCCESS && userResources.ownedWorkflows && userResources.ownedWorkflows.length > 0)  // If we know which resources the user has, we can show a <select> option. Otherwise, enable manual input.
+              ? <select
+                  value={workflowOutput.retireTarget}
+                  onChange={(e) => { workflowOutput.setRetireTarget(e.target.value) }}
+                >
+                  {userResources.ownedWorkflows.map(item => (
+                    <option key={`retire-from-workflow-${item.id}`} value={item.id}>
+                      {item.id} - {item.display_name}
+                  </option>
+                  ))}
+                </select>
+
+              : <input
+                  value={workflowOutput.retireTarget}
+                  onChange={(e) => { workflowOutput.setRetireTarget(e.target.value) }}
+                />
+            }
           </div>
           
           <div>

--- a/src/components/MLTaskManager/ProcessAndOutput.js
+++ b/src/components/MLTaskManager/ProcessAndOutput.js
@@ -49,7 +49,7 @@ class ProcessAndOutput extends React.Component {
             />
             {(userResources.status === ASYNC_STATES.SUCCESS && userResources.ownedSubjectSets && userResources.ownedSubjectSets.length > 0)  // If we know which resources the user has, we can show a <select> option. Otherwise, enable manual input.
               ? <div>
-                  or, choose from: &nbsp;
+                  <span>or, choose from: &nbsp;</span>
                   <select
                     value={workflowOutput.moveTarget}
                     onChange={(e) => { workflowOutput.setMoveTarget(e.target.value) }}
@@ -100,7 +100,7 @@ class ProcessAndOutput extends React.Component {
             
             {(userResources.status === ASYNC_STATES.SUCCESS && userResources.ownedWorkflows && userResources.ownedWorkflows.length > 0)  // If we know which resources the user has, we can show a <select> option.
               ? <div>
-                  or, choose from: &nbsp;
+                  <span>or, choose from: &nbsp;</span>
                   <select
                     value={workflowOutput.retireTarget}
                     onChange={(e) => { workflowOutput.setRetireTarget(e.target.value) }}

--- a/src/store/AppStore.js
+++ b/src/store/AppStore.js
@@ -4,6 +4,7 @@ import { MLTaskStore } from './MLTaskStore'
 import { MLResultsStore } from './MLResultsStore'
 import { MLSelectionStore } from './MLSelectionStore'
 import { WorkflowOutputStore } from './WorkflowOutputStore'
+import { UserResourcesStore } from './UserResourcesStore'
 
 const DEMO_MODE_STORAGE_KEY = 'demoMode'
 
@@ -13,6 +14,8 @@ const AppStore = types.model('AppStore', {
   demoMode: types.optional(types.boolean, localStorage.getItem(DEMO_MODE_STORAGE_KEY) === 'yes'),
   
   auth: types.optional(AuthStore, () => AuthStore.create({})),
+  
+  userResources: types.optional(UserResourcesStore, () => UserResourcesStore.create({})),
   
   mlTask: types.optional(MLTaskStore, () => MLTaskStore.create({})),  // We can use {} to set the initial values of a store
   mlResults: types.optional(MLResultsStore, () => MLResultsStore.create({})),

--- a/src/store/AuthStore.js
+++ b/src/store/AuthStore.js
@@ -23,7 +23,8 @@ const AuthStore = types.model('AuthStore', {
       self.status = ASYNC_STATES.SUCCESS
       self.user = user
       
-      root.userResources.fetch()
+      root.userResources.reset()
+      if (user) root.userResources.fetch()
     } catch (err) {
       self.status = ASYNC_STATES.ERROR
     }

--- a/src/store/AuthStore.js
+++ b/src/store/AuthStore.js
@@ -1,4 +1,4 @@
-import { flow, types } from 'mobx-state-tree'
+import { flow, getRoot, types } from 'mobx-state-tree'
 import oauth from 'panoptes-client/lib/oauth'
 
 import { ASYNC_STATES } from '@util'
@@ -15,12 +15,15 @@ const AuthStore = types.model('AuthStore', {
   },
 
   checkUser: flow(function * checkUser () {
+    const root = getRoot(self)
     self.status = ASYNC_STATES.FETCHING
     
     try {
       const user = yield oauth.checkCurrent()
       self.status = ASYNC_STATES.SUCCESS
       self.user = user
+      
+      root.userResources.fetch()
     } catch (err) {
       self.status = ASYNC_STATES.ERROR
     }

--- a/src/store/AuthStore.js
+++ b/src/store/AuthStore.js
@@ -38,14 +38,6 @@ const AuthStore = types.model('AuthStore', {
       self.status = ASYNC_STATES.ERROR
     }
   }),
-
-  setStatus (val) {
-    self.status = val
-  },
-
-  setUser (val) {
-    self.user = val
-  },
 }))
 
 const computeRedirectURL = (window) => {

--- a/src/store/UserResourcesStore.js
+++ b/src/store/UserResourcesStore.js
@@ -28,8 +28,6 @@ const UserResourcesStore = types.model('UserResourcesStore', {
 
   fetch: flow(function * fetch (url) {
     
-    console.log('+++ FETCH')
-    
     try {
       let data = []
       let projects = []
@@ -54,9 +52,7 @@ const UserResourcesStore = types.model('UserResourcesStore', {
         .catch(err => { throw err })
       projects.push(...data)
       
-      //projects.forEach(flow (function * fetch_workflow (project) {
       for (let i = 0; i < projects.length; i++) {
-        
         let project = projects[i];
         
         // Fetch all associated workflows.
@@ -77,11 +73,6 @@ const UserResourcesStore = types.model('UserResourcesStore', {
           .catch(err => { throw err })
         subjectSets.push(...data)
       }
-      //}))
-      
-      console.log('+++ PROJECTS: ', projects.length, projects)
-      console.log('+++ WORKFLOWS: ', workflows.length, workflows)
-      console.log('+++ SUBJECT SETS: ', subjectSets.length, subjectSets)
       
       self.ownedProjects = projects
       self.ownedWorkflows = workflows

--- a/src/store/UserResourcesStore.js
+++ b/src/store/UserResourcesStore.js
@@ -54,7 +54,10 @@ const UserResourcesStore = types.model('UserResourcesStore', {
         .catch(err => { throw err })
       projects.push(...data)
       
-      projects.forEach(flow (function * fetch_workflow (project) {
+      //projects.forEach(flow (function * fetch_workflow (project) {
+      for (let i = 0; i < projects.length; i++) {
+        
+        let project = projects[i];
         
         // Fetch all associated workflows.
         data = yield apiClient.type('workflows')
@@ -73,7 +76,12 @@ const UserResourcesStore = types.model('UserResourcesStore', {
           .then(res => res)
           .catch(err => { throw err })
         subjectSets.push(...data)
-      }))
+      }
+      //}))
+      
+      console.log('+++ PROJECTS: ', projects.length, projects)
+      console.log('+++ WORKFLOWS: ', workflows.length, workflows)
+      console.log('+++ SUBJECT SETS: ', subjectSets.length, subjectSets)
       
       self.ownedProjects = projects
       self.ownedWorkflows = workflows

--- a/src/store/UserResourcesStore.js
+++ b/src/store/UserResourcesStore.js
@@ -1,0 +1,35 @@
+import { flow, getRoot, types } from 'mobx-state-tree'
+import { ASYNC_STATES } from '@util'
+import config from '@config'
+import superagent from 'superagent'
+
+const UserResourcesStore = types.model('UserResourcesStore', {
+  
+  operation: types.optional(types.enumeration('operation', ['', 'subjectSets', 'workflows']), ''),
+  status: types.optional(types.string, ASYNC_STATES.IDLE),
+  statusMessage: types.maybe(types.string),
+  
+  ownedProjects: types.frozen({}),
+  ownedSubjectSets: types.frozen({}),
+  ownedWorkflows: types.frozen({}),
+  
+}).actions(self => ({
+  
+  reset () {
+    self.operation = ''
+    self.status = ASYNC_STATES.IDLE
+    self.statusMessage = undefined
+    
+    self.ownedProjects = {}
+    self.ownedSubjectSets = {}
+    self.ownedWorkflows = {}
+  },
+
+  fetch: flow(function * fetch (url) {
+    
+    console.log('+++ FETCH')
+    
+  }),
+}))
+
+export { UserResourcesStore }

--- a/src/store/UserResourcesStore.js
+++ b/src/store/UserResourcesStore.js
@@ -30,11 +30,15 @@ const UserResourcesStore = types.model('UserResourcesStore', {
   },
 
   fetch: flow(function * fetch (url) {
+    const root = getRoot(self)
+    
     try {
       let data = []
       let projects = []
       let workflows = []
       let subjectSets = []
+      
+      self.status = ASYNC_STATES.FETCHING
 
       // Fetch all projects this user is an owner of.
       data = yield apiClient.type('projects')
@@ -79,6 +83,11 @@ const UserResourcesStore = types.model('UserResourcesStore', {
       self.ownedProjects = projects
       self.ownedWorkflows = workflows
       self.ownedSubjectSets = subjectSets
+      
+      if (workflows.length > 0) root.workflowOutput.setRetireTarget(workflows[0].id)
+      if (subjectSets.length > 0) root.workflowOutput.setMoveTarget(subjectSets[0].id)
+      
+      self.status = ASYNC_STATES.SUCCESS
     
     } catch (err) {
       const message = err && err.toString() || undefined

--- a/src/store/UserResourcesStore.js
+++ b/src/store/UserResourcesStore.js
@@ -24,10 +24,12 @@ const UserResourcesStore = types.model('UserResourcesStore', {
     self.ownedProjects = []
     self.ownedSubjectSets = []
     self.ownedWorkflows = []
+    
+    const root = getRoot(self)
+    root.workflowOutput.resetTargets()
   },
 
   fetch: flow(function * fetch (url) {
-    
     try {
       let data = []
       let projects = []

--- a/src/store/WorkflowOutputStore.js
+++ b/src/store/WorkflowOutputStore.js
@@ -18,6 +18,14 @@ const WorkflowOutputStore = types.model('WorkflowOutputStore', {
     self.operation = ''
     self.status = ASYNC_STATES.IDLE
     self.statusMessage = undefined
+    
+    self.moveTarget = ''
+    self.retireTarget = ''
+  },
+  
+  resetTargets () {
+    self.moveTarget = ''
+    self.retireTarget = ''
   },
   
   setMoveTarget (val) {

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -22,6 +22,11 @@
     margin: 0.5em;
     padding: 0.5em 1em;
   }
+  
+  .greyed-out {
+    color: $mid-colour;
+    background: $mid-back-colour;
+  }
 }
 
 .button {

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -12,6 +12,11 @@
   fieldset {
     margin: 0.5em;
     
+    span {
+      font-size: 0.8em;
+      line-height: 1.2em;
+    }
+    
     var .material-icons {
       vertical-align: bottom;
     }


### PR DESCRIPTION
## PR Overview

Requires #27 

This PR attempts to make life easier for researchers. Instead of typing into the the ML Task Manager the Workflow ID that they want to retire Subjects from or the Subject Set ID they want to move Subjects to, the app should be able to figure out which Workflows and Subject Sets the user has access to.

- When the user is signed in, the app should query all Projects the user is an `owner` or `collaborator` of, and then,
- fetch all Workflows and Subject Sets  associated with these Projects, and then,
- provide a dropdown or auto-complete feature in the ML Task Manager for users to select their Workflow/Subject Set.

Thoughts:
- Should users still be able to arbitrarily specify a Workflow or Subject Set that they don't own? Uhh... I'm not sure, really.

### Status

WIP

Currently targeting #27 `output-workflow` and should be re-targeted to `master` once that's merged.
