### PR TITLE
Proxy Server improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.env
 node_modules
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -2463,6 +2463,11 @@
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "Zooniverse <contact@zooniverse.org> (https://www.zooniverse.org/)",
   "license": "Apache-2.0",
   "dependencies": {
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "json2csv": "^4.5.2",
     "mobx": "^5.11.0",

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -1,5 +1,6 @@
 const express = require('express')
 const request = require('request')  // Note: superagent doesn't work well in this scenario.
+require('dotenv').config()
 
 const server = express()
 

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -7,6 +7,7 @@ const server = express()
 const config = {
   origins: process.env.ORIGINS || 'http://localhost:3000;http://local.zooniverse.org:3000',
   targets: process.env.TARGETS || 'http://example.com;https://www.zooniverse.org/',
+  url_for_msml: process.env.URL_FOR_MSML || '',  // Microsofot Machine Learning
   port: process.env.PORT || 3666,
 }
 
@@ -28,7 +29,15 @@ server.use(function (req, res, next) {
 
 function proxyGet (req, res) {
   try {
-    const url = req.query.url || ''
+    let url = req.query.url || ''
+    const predefined_target = req.query.target || ''
+    
+    switch (predefined_target) {
+      case 'msml':
+        url = `${config.url_for_msml}${url}`
+        break
+    }
+    
     const acceptableTargets = config.targets.split(';')
     const urlIsAcceptable = acceptableTargets.find(function (target) {
       return url.toLowerCase().startsWith(target.toLowerCase())

--- a/src/components/ConfigForm.js
+++ b/src/components/ConfigForm.js
@@ -25,24 +25,9 @@ class ConfigForm extends React.Component {
         <h2>App Config</h2>
         <p>{state.message}</p>
       
-        {Object.keys(config).map((key) => {
-          return (
-            <fieldset key={key}>
-              <legend>{key}</legend>
-              <div className="flex-row">
-                <input
-                  className="long text input flex-item grow"
-                  defaultValue={config[key]}
-                  onChange={(e) => {
-                    localStorage.setItem(key, e.target.value)
-                    this.setState({ message: MESSAGE.CHANGED })
-                  }}
-                />
-              </div>
-            </fieldset>
-          )
-        })}
-  
+        {this.render_field('appRootUrl')}
+        {this.render_field('proxyUrl')}
+
         <div className="action panel">
           <button
             className="danger button"
@@ -58,6 +43,24 @@ class ConfigForm extends React.Component {
           </button>
         </div>
       </form>
+    )
+  }
+  
+  render_field (key) {
+    return (
+      <fieldset key={key}>
+        <legend>{key}</legend>
+        <div className="flex-row">
+          <input
+            className="long text input flex-item grow"
+            defaultValue={config[key]}
+            onChange={(e) => {
+              localStorage.setItem(key, e.target.value)
+              this.setState({ message: MESSAGE.CHANGED })
+            }}
+          />
+        </div>
+      </fieldset>
     )
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -14,7 +14,6 @@ if (!env.match(/^(production|staging|development)$/)) {
 
 const config = {
   appRootUrl: localStorage.getItem('appRootUrl') || `${window.location.origin}${window.location.pathname}`,
-  mlServiceUrl: localStorage.getItem('mlServiceUrl') || 'https://www.zooniverse.org/api',
   proxyUrl: localStorage.getItem('proxyUrl') || 'http://localhost:3666',
   panoptesAppId: (env === 'production')
     ? ''

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -39,8 +39,8 @@ const MLTaskStore = types.model('MLTaskStore', {
     self.status = ASYNC_STATES.FETCHING
     self.statusMessage = undefined
 
-    const serviceUrl = `${config.mlServiceUrl}${TASKS_ENDPOINT}/${self.id}`
-    const proxiedUrl = `${config.proxyUrl}?url=${encodeURIComponent(serviceUrl)}`
+    const serviceUrl = `${TASKS_ENDPOINT}/${self.id}`
+    const proxiedUrl = `${config.proxyUrl}?url=${encodeURIComponent(serviceUrl)}&target=msml`
     
     const url = (!root.demoMode)
       ? proxiedUrl


### PR DESCRIPTION
## PR Overview

This PR intends to improve the proxy server

- [x] The proxy should accept short-hand "targets" so the front end doesn't need to spell out the URL of the ML service. e.g. `http://proxy-server/?url=/task/123&target=msml` instead of `http://proxy-server/?url=http://fully-exposed-url-for-ms-ml-service/task/123`
- [x] In tandem, when fetching task results from the ML service, the front end should specify short-hand targets instead of spelling out the full URL.
- [x] More environmental variables should be defined:
  - `URL_FOR_MSML` specifies the URL for the Microsoft Machine Learning service.
- [x] `.gitignore` should ignore `.env`, and the proxy server NodeJS script should be able to read `.env`.
  - (Apparently this isn't native to NodeJS; I had to install the `dotenv` dependency.) 

### Status

WIP