### PR TITLE
Update Proxy Server to read Kubernetes secrets

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -19,3 +19,19 @@ spec:
           image: zooniverse/zoo-ml-subject-assistant:__IMAGE_TAG__
           ports:
             - containerPort: 80
+          env:
+            - name: ORIGINS
+              valueFrom:
+                secretKeyRef:
+                  name: subject-assistant-proxy-conf
+                  key: ORIGINS
+            - name: TARGETS
+              valueFrom:
+                secretKeyRef:
+                  name: subject-assistant-proxy-conf
+                  key: TARGETS
+            - name: URL_FOR_MSML
+              valueFrom:
+                secretKeyRef:
+                  name: subject-assistant-proxy-conf
+                  key: URL_FOR_MSML


### PR DESCRIPTION
## PR Overview

This PR allows the Proxy Server to read specific _Kubernetes secrets._ This is the server-level equivalent of setting up _environmental variables_ in a `.env` file for local development.

Also, note: due to separate dev work, the Proxy Server is now available at `http://subject-assistant-proxy.zooniverse.org/`

External Requirement:
- Secrets need to be set up for `subject-assistant-proxy-conf` on Kubernetes.

### Status

Merging and monitoring functionality of proxy server.