### PR TITLE
Update PJC to 3.0.0 (minus the RC)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4495,9 +4495,9 @@
       "dev": true
     },
     "json-api-client": {
-      "version": "5.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.0.0-rc.0.tgz",
-      "integrity": "sha512-xnGt9yfU9s3v7Lll3gEVY1xJd/auR0AaLmph2KBhK9CclrSxfpoP9rvMX5Qh1A7CBjIGai0JpJm8bjTWf9o2Yw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.0.0.tgz",
+      "integrity": "sha512-HFXao3PkvgNQOlD1iAwKbR+tuT+lYiyyu6Q/FxPoTRai1DAv7c6pha0gvOFxe/FrkaUu1/v6btr2OdkzFVGX0A==",
       "requires": {
         "normalizeurl": "~0.1.3",
         "superagent": "^3.8.3"
@@ -5528,11 +5528,11 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "3.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.0.0-rc.0.tgz",
-      "integrity": "sha512-eWKvvMXzIVdt8YMwF6PdG4K7dSHlP8LpSI0TJ9C3IME2U96YDEBsKiZKUaP+5IzJyv21Mj9sXlmVRL0KYtNH3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.0.0.tgz",
+      "integrity": "sha512-LEeFBveR37HBbu8keWuTWaFkCMr2gvnoQ93M2O1o4wGF2BVQIb2lJlx5BxFMiCD33xwRBYVtMxijHwAaR159mg==",
       "requires": {
-        "json-api-client": "~5.0.0-rc.0",
+        "json-api-client": "~5.0.0",
         "local-storage": "^1.4.2",
         "sugar-client": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mobx": "^5.11.0",
     "mobx-react": "^6.1.1",
     "mobx-state-tree": "^3.14.0",
-    "panoptes-client": "^3.0.0-rc.0",
+    "panoptes-client": "^3.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.1.2",


### PR DESCRIPTION
## PR Overview

This PR updates the Panoptes JavaScript Client... again. For some reason, I'm encountering CORS errors on `http://subject-assistant.zooniverse.org/` that should have been solved by PJC 3.0.0, so let's try a re-update.

Note: yes, I DID run `npm run build`, but there doesn't seem to be any changes to the `/app/main.js` so... this PR might not actually fix anything, and there might still be an issue... but let's try merging this anyway.