### PR TITLE
Increase RAM for proxy server (50Mi -> 100Mi)

### DIFF
--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -19,10 +19,10 @@ spec:
           image: zooniverse/zoo-ml-subject-assistant:__IMAGE_TAG__
           resources:
             requests:
-              memory: "50Mi"
+              memory: "100Mi"
               cpu: "10m"
             limits:
-              memory: "50Mi"
+              memory: "100Mi"
               cpu: "500m"
           ports:
             - containerPort: 80


### PR DESCRIPTION
## PR Overview

Related issue: #55

As described in the issue, attempting to fetch data for certain tasks from the MS server can result in an unidentified error on the front end. Turns out, the Proxy Server shuts down with a 502 error should the target file on the MS server be too large. (The container error is a `OOMKilled`, so yeah, it's a memory issue.)

This PR attempts to fix the problem by increasing the amount of RAM available to the Proxy Server.

### Status

Attempt 1. We might need a few more PRs (or commits) to get this thing working.