### PR TITLE
add status 200 json usage response on default route

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     environment:
       - ORIGINS=${ORIGINS}
       - TARGETS=${TARGETS}
+      - REVISION=fakerevision123
     volumes:
       - ./server:/usr/src/server
 

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -48,7 +48,7 @@ function proxyGet (req, res) {
       // default route
       res.json({
         'revision': config.revision,
-        'usage': 'Please supply a URL via query params, e.g. ?url=$URL'
+        'usage': 'Please supply either a ?url=$URL or ?target=msml query param'
       });
 
     } else if (!urlIsAcceptable) {


### PR DESCRIPTION
- Respond with json by default (we're a json API proxy)
- Avoid 500'ing on default / index route, instead 200 with a usage message.
- Add a 422 json error message if the target service URL is not acceptable

It appear that 500 responses on the default route are breaking our k8s cert-manager's ability to issue certificates. I'm modifying the default / error response objects here to avoid 500 status codes and to return json (this is a json API request proxy).