### PR TITLE
Fix Proxy Server after Node 14 upgrade

### DIFF
--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -71,7 +71,7 @@ function proxyGet (req, res) {
     } else {
       superagent.get(url)
       .then(proxyRes => {        
-        let status = (proxyRes && proxyRes.statusCode) || 500
+        let status = (proxyRes.statusCode) || 500
         let data = isAValidObject(proxyRes.body)
         ? proxyRes.body  // Handles JSON responses
         : proxyRes.text || ''  // Handles everything else

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -12,6 +12,17 @@ const config = {
   revision: process.env.REVISION || '',
 }
 
+/*
+Checks to see if the Response.body is a valid JSON object (instead of
+undefined or an empty {} object)
+ */
+function isAValidObject (obj) {
+  return obj && Object.keys(obj).length > 0
+}
+
+/*
+Main server functionality
+ */
 server.use(function (req, res, next) {
   const origin = req.get('origin') || ''
   const acceptableOrigins = config.origins.split(';')
@@ -58,17 +69,8 @@ function proxyGet (req, res) {
         .json({'error': 'Target URL is not in the whitelist'});
 
     } else {
-      
-      // TODO: test error handling
-
       superagent.get(url)
       .then(proxyRes => {        
-        console.log(proxyRes.text)
-        
-        function isAValidObject (obj) {
-          return obj && Object.keys(obj).length > 0
-        }
-        
         let status = (proxyRes && proxyRes.statusCode) || 500
         let data = isAValidObject(proxyRes.body)
         ? proxyRes.body  // Handles JSON responses

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -1,5 +1,5 @@
 const express = require('express')
-const request = require('request')  // Note: superagent doesn't work well in this scenario.
+const superagent = require('superagent')
 require('dotenv').config()
 
 const server = express()
@@ -58,31 +58,36 @@ function proxyGet (req, res) {
         .json({'error': 'Target URL is not in the whitelist'});
 
     } else {
+      
+      // TODO: test error handling
 
-      request(url, function (proxyErr, proxyRes) {
-        // Note: proxyRes.body is unparsed data.
-
-        let status = (proxyRes && proxyRes.statusCode) || 500
-        let statusMessage = (proxyRes && proxyRes.statusMessage) || 'No data'
-        let data = (proxyRes && proxyRes.body) || `ERROR: ${statusMessage}`
-
-        if (proxyErr) {
-          status = 500
-          data = proxyErr.toString()
+      superagent.get(url)
+      .then(proxyRes => {        
+        console.log(proxyRes.text)
+        
+        function isAValidObject (obj) {
+          return obj && Object.keys(obj).length > 0
         }
+        
+        let status = (proxyRes && proxyRes.statusCode) || 500
+        let data = isAValidObject(proxyRes.body)
+        ? proxyRes.body  // Handles JSON responses
+        : proxyRes.text || ''  // Handles everything else
 
         res
-          .status(status)
-          .send(data)
-
-      });
+        .status(status)
+        .send(data)
+      })
+      .catch(err => {
+        throw err
+      })
     }
   } catch (err) {
     const errMessage = err && err.toString() || '???'
 
     res
-      .status(500)
-      .send(`ERROR: ${errMessage}`)
+    .status(500)
+    .send(`ERROR: ${errMessage}`)
   }
 }
 


### PR DESCRIPTION
## PR Overview

This PR fixes an issue where the proxy server - https://subject-assistant-proxy.zooniverse.org/ - is returning a 503 error. The actual error message is "Error: Cannot find module 'request'"

Tagging @camallen as an FYI because this involves server-side error logs.

- Issue: running `npm run proxy-server` immediately results in a crash with "Error: Cannot find module 'request'"
- Diagnosis: it turns out that Node no longer supports the hitherto evergreen [`request` library](https://www.npmjs.com/package/request). This unexpected deprecation collided into us when we [upgraded to Node 14](https://github.com/zooniverse/zoo-ml-subject-assistant/pull/66) without testing the proxy server.
- Solution: replace `request` with `superagent`

Side note: Turns out my previous attempts to use superagent with Node.js failed simply because Node.js doesn't support `yield`, so an ol'-fashioned Promise solves the issue.

### Status

This is ready to go; the proxy server and its services works on normal conditions (pinging an [example HTTPS+JSON URL,](https://jsonplaceholder.typicode.com/todos/1) or an [example HTTP+HTML URL](http://example.com/)), but I want to run a few extra tests to ensure error handling works as expected.