### PR TITLE
switch to node 14 slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 as builder
+FROM node:14-slim as builder
 
 RUN mkdir -p /usr/src
 WORKDIR /usr/src/


### PR DESCRIPTION
use the smaller 'slim' image to create the proxy server, this reduces the underlying docker image by ~70% (now ~300 MB vs ~1GB) without any decrease in node functionality. 

Also sim images have less packages installed and thus less vulnerabilities in them. 