### PR TITLE
December 2021 Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,5 @@ Environmental (ENV) Config Values:
   requests to. e.g. `TARGETS=http://example.com/;http://www.example.com/`
 - `URL_FOR_MSML`: URL for the Microsoft Megadetector ML service. Used by the
   Proxy Server.
+- `PROXY_HOST`: URL of the Proxy Server. Used by the Subject Assistant to find
+  the proxy. Can be overwritten via the Subject Assistant's in-app config.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,42 @@
 # Zooniverse ML Subject Assistant
 
-Machine Learning-assisted web app for processing Zooniverse Subjects.
+In short: Machine Learning-assisted web app for processing Zooniverse Subjects.
+
+In long: the Subject Assistant aims to provide (wildlife camera trap-based)
+project owners an optional Machine Learning-assisted (ML) step in the Subject
+upload pipeline. Powered by external ML services, project owners can, for
+example, identify wildlife in photos before passing the difficult ones to
+volunteers.
 
 https://subject-assistant.zooniverse.org/
+
+- The Subject Assistant is just the front-end that easily allows Zooniverse
+  project owners to submit their Zooniverse Subjects to certain ML services,
+  and pull the results for further processing.
+- The ML services are external to this project.
+- This repo also contains the Proxy Server, which allows the Subject Assistant
+  (on a `*.zooniverse.org` domain) to download data from non-Zooniverse domains
+  (i.e. the external ML services), without running into CORS errors.
+- This repo is closely related to [Hamlet](https://github.com/zooniverse/hamlet),
+  which is what actually uploads Subjects to external ML services. (It's a
+  multi-step process that can probably optimised, but for now it works.)
+
+**2021/22 Local Development Notes**
+
+The current code is optimised for deployment, so some workarounds are required
+to get the Subject Assistant (and the Proxy Server) working on localhost.
+- Since `https://hamlet-staging.zooniverse.org/` points to `production` and
+  doesn't have a `staging` equivalent (despite its name!), local development
+  **also points to production** (!!!)
+- `npm start` now sets ENV=production
+- The Zooniverse oAuth app now allows `localhost` as a return URL. (This should
+  be enabled/disabled as necessary!)
+- On local, the Subject Assistant runs on HTTPS (for auth security) but the
+  Proxy Server runs on HTTP (because there's no easy self-hosted SSL solution
+  for Node.js scripts, AFAIK). To allow mixed-content, the local testing must
+  be done on `localhost:3000` (and `localhost:3666`), not the usual alias of
+  `local.zooniverse:3000`. This is because Chrome & Firefox are much more
+  forgiving of mixed-content on `localhost` than on other domains.
 
 ## Usage
 
@@ -30,7 +64,7 @@ Requires:
   featuring images of animal from camera traps.
 
 How to Use:
-- **TODO**
+- Instructions are on the web app.
 
 ## Dev Notes
 
@@ -42,7 +76,7 @@ Intended Developers:
 - Web developers (HTML/JS) who are sorta familiar with the [Zooniverse](https://github.com/zooniverse/)
   dev environment.
 
-Requires: 
+Requires:
 - `npm` - the Node Package Manager, usually installed together with [Node](https://nodejs.org/)
 
 Project Overview:
@@ -55,7 +89,7 @@ Project Overview:
   - can be run locally by running `npm run start`
   - is built by running `npm run build` and auto-deployed on GitHub Pages as soon as changes are merged to `master`.
 - The Proxy Server...
-  - exists to pass information between the front end and the ML servers, to bypass the CORS security issues that prevents data fetches between different domains. 
+  - exists to pass information between the front end and the ML servers, to bypass the CORS security issues that prevents data fetches between different domains.
   - is purely server-side, and is used to hide secrets from the user-facing front end.
   - has its code stored in `/server`
   - is auto-deployed to our Kubernetes systems (via Jenkins, presumably) as soon as changes are merged to `master`
@@ -85,16 +119,10 @@ External dependencies:
 - Zooniverse Kubernetes system for hosting Proxy Server
 - Both set up to use `*.zooniverse.org` domain names.
 
-### Special Dev Notes: Deployment Wonkiness
-
-Hi, Shaun here. As of 2019.12.06 there is an issue that I haven't correctly solved: there are TWO `index.html` files, which might result in a messy deployment.
-
-- The first `index.html` created for production environment is created by running `npm run build` and is found in `/app/index.html`.
-- The second `index.html` is found in the root `/` folder, and is the actual `index.html` users see when they go to `https://subject-assistant.zooniverse.org/`
-
-This wonkiness was the result of a change of deployment targets, from serving `/app` on one of our static site buckets to simply serving `/` from github.io via `https://subject-assistant.zooniverse.org/`
-
-For the moment, the manual solution is to:
-- run `npm run build`
-- copy `/app/index.html` to `/index.html`
-- change `<script src="./main.js"></script>` to `<script src="./app/main.js"></script>`
+Environmental (ENV) Config Values:
+- `ORIGINS`: acceptable Zooniverse domains, which the Proxy Server accepts
+  requests from. e.g. `ORIGINS=https://subject-assistant.zooniverse.org/`
+- `TARGETS`: acceptable external domains/URLs, which the Proxy Server will send
+  requests to. e.g. `TARGETS=http://example.com/;http://www.example.com/`
+- `URL_FOR_MSML`: URL for the Microsoft Megadetector ML service. Used by the
+  Proxy Server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "zoo-ml-subject-assistant",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -3396,6 +3397,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1528,10 +1528,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+    "node_modules/ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true,
       "engines": [
         "node >= 0.8.0"
@@ -5076,9 +5076,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-to-regexp": {
@@ -6892,9 +6892,9 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
@@ -7082,12 +7082,12 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz",
-      "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
+      "integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
       "dev": true,
       "dependencies": {
-        "ansi-html": "0.0.7",
+        "ansi-html-community": "0.0.8",
         "bonjour": "^3.5.0",
         "chokidar": "^2.1.8",
         "compression": "^1.7.4",
@@ -7126,6 +7126,14 @@
       },
       "engines": {
         "node": ">= 6.11.5"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-dev-server/node_modules/debug": {
@@ -9000,10 +9008,10 @@
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
-    "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+    "ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true
     },
     "ansi-regex": {
@@ -11860,9 +11868,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -13381,9 +13389,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
@@ -13543,12 +13551,12 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz",
-      "integrity": "sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==",
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.3.tgz",
+      "integrity": "sha512-3x31rjbEQWKMNzacUZRE6wXvUFuGpH7vr0lIEbYpMAG9BOxi0928QU1BBswOAP3kg3H1O4hiS+sq4YyAn6ANnA==",
       "dev": true,
       "requires": {
-        "ansi-html": "0.0.7",
+        "ansi-html-community": "0.0.8",
         "bonjour": "^3.5.0",
         "chokidar": "^2.1.8",
         "compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Machine Learning-assisted web app for processing Zooniverse Subjects.",
   "main": "index.js",
   "scripts": {
-    "start": "export NODE_ENV=production ; webpack serve",
+    "start": "export NODE_ENV=production ; export PROXY_HOST=http://localhost:3666 ; webpack serve",
     "clean": "rm -fr ./app",
     "build": "export BABEL_ENV=production ; export NODE_ENV=production ; npm run clean && webpack --mode=production",
     "proxy-server": "node server/proxy-server.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Machine Learning-assisted web app for processing Zooniverse Subjects.",
   "main": "index.js",
   "scripts": {
-    "start": "webpack serve",
+    "start": "export NODE_ENV=production ; webpack serve",
     "clean": "rm -fr ./app",
     "build": "export BABEL_ENV=production ; export NODE_ENV=production ; npm run clean && webpack --mode=production",
     "proxy-server": "node server/proxy-server.js"

--- a/src/components/MLTaskManager/Fetch.js
+++ b/src/components/MLTaskManager/Fetch.js
@@ -52,7 +52,7 @@ function Fetch (props) {
             className="action button flex-item"
             type="button"
             onClick={(e) => {
-              mlTask.fetch()
+              mlTask.doFetch()
               stopEvent(e)
               history.push(`/tasks/${mlTask.id}`)
             }}

--- a/src/components/MLTaskManager/Fetch.js
+++ b/src/components/MLTaskManager/Fetch.js
@@ -1,16 +1,20 @@
 import React, { useContext } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useHistory } from 'react-router-dom'
 import { observer } from 'mobx-react'
 import AppContext from '@store'
 import { ASYNC_STATES, statusIcon, stopEvent } from '@util'
 
 function Fetch (props) {
   const context = useContext(AppContext)
+  const history = useHistory()
   const mlTask = context.mlTask
   const mlResults = context.mlResults
 
   const { task_id } = useParams()
-  if (task_id !== undefined) {
+  const taskIsUndefined = mlTask.id === '' || mlTask.id === undefined
+
+  // Set Task ID, if user directly accessed URL with Task ID
+  if (task_id !== undefined && taskIsUndefined) {
     mlTask.setId(task_id)
   }
 
@@ -41,7 +45,7 @@ function Fetch (props) {
           <input
             className="text input flex-item grow"
             value={mlTask.id}
-            readOnly={task_id !== undefined}
+            readOnly={false}
             onChange={(e) => { mlTask.setId(e.target.value) }}
           />
           <button
@@ -50,6 +54,7 @@ function Fetch (props) {
             onClick={(e) => {
               mlTask.fetch()
               stopEvent(e)
+              history.push(`/tasks/${mlTask.id}`)
             }}
           >
             Fetch

--- a/src/components/MLTaskManager/ProcessAndOutput.js
+++ b/src/components/MLTaskManager/ProcessAndOutput.js
@@ -10,19 +10,19 @@ class ProcessAndOutput extends React.Component {
   constructor (props) {
     super(props)
   }
-  
+
   render () {
     const mlTask = this.context.mlTask
     const mlResults = this.context.mlResults
     const mlSelection = this.context.mlSelection
     const workflowOutput = this.context.workflowOutput
     const userResources = this.context.userResources
-    
+
     // If the results aren't ready, don't render this component.
     if (mlTask.status !== ASYNC_STATES.SUCCESS || mlResults.status !== ASYNC_STATES.SUCCESS) {
       return null
     }
-    
+
     return (
       <form className="form" onSubmit={(e) => { return stopEvent(e) }}>
         <h2>Process Selected Images</h2>
@@ -38,7 +38,7 @@ class ProcessAndOutput extends React.Component {
             Export
           </button>
         </fieldset>
-            
+
         <fieldset>
           <legend>Move Subjects</legend>
           <div>
@@ -66,7 +66,7 @@ class ProcessAndOutput extends React.Component {
               : null
             }
           </div>
-          
+
           <div>
             <button
               className="action button"
@@ -86,9 +86,9 @@ class ProcessAndOutput extends React.Component {
               : null
             }
           </div>
-            
+
         </fieldset>
-            
+
         <fieldset>
           <legend>Retire Subjects</legend>
           <div>
@@ -115,7 +115,7 @@ class ProcessAndOutput extends React.Component {
               : null
             }
           </div>
-          
+
           <div>
             <button
               className="action button"
@@ -135,23 +135,55 @@ class ProcessAndOutput extends React.Component {
               : null
             }
           </div>
-            
+
+        </fieldset>
+
+        <fieldset>
+          <legend>Create &amp; Move to New Subject Set</legend>
+          <div>
+            <span>Choose a name for your new Subject Set: &nbsp;</span>
+            <input
+              value={workflowOutput.createTarget}
+              onChange={(e) => { workflowOutput.setCreateTarget(e.target.value) }}
+            />
+          </div>
+
+          <div>
+            <button
+              className="action button"
+              onClick={this.doCreate.bind(this)}
+            >
+              Create &amp; Move
+            </button>
+
+            {(workflowOutput.operation === 'create')
+              ? <var className="block">
+                  {workflowOutput.status} {statusIcon(workflowOutput.status)}
+                </var>
+              : null
+            }
+            {(workflowOutput.operation === 'create' && workflowOutput.statusMessage && workflowOutput.statusMessage.length > 0)
+              ? <var className="error block">{workflowOutput.statusMessage}</var>
+              : null
+            }
+          </div>
+
         </fieldset>
       </form>
     )
   }
-  
+
   doExport () {
     const mlSelection = this.context.mlSelection
     const selection = mlSelection.selection.toJSON()
     let csvData = ''
     if (selection.length > 0) csvData = parse(selection, {})
-    
+
     const fileStream = streamSaver.createWriteStream('subject-assistant.csv', {})
-    
+
     const onSuccess = () => { console.log('EXPORT SUCCESS') }
     const onError = () => { console.error('EXPORT ERROR') }
-    
+
     new Response(csvData).body.pipeTo(fileStream).then(onSuccess, onError)
   }
 
@@ -160,15 +192,15 @@ class ProcessAndOutput extends React.Component {
     const mlSelection = this.context.mlSelection
     const selection = mlSelection.selection.toJSON() || []
     const subjectIds = getUniqueSubjectIds(selection)
-    
+
     const moveTarget = workflowOutput.moveTarget.trim()
-    
+
     if (moveTarget.length === 0) {
       // TODO: better warnings
       alert('Please specify a Subject Set to which these Subjects will be moved')
       return
     }
-    
+
     workflowOutput.move(subjectIds, moveTarget)
   }
 
@@ -177,16 +209,33 @@ class ProcessAndOutput extends React.Component {
     const mlSelection = this.context.mlSelection
     const selection = mlSelection.selection.toJSON() || []
     const subjectIds = getUniqueSubjectIds(selection)
-    
+
     const retireTarget = workflowOutput.retireTarget.trim()
-    
+
     if (retireTarget.length === 0) {
       // TODO: better warnings
       alert('Please specify a Workflow from which these Subjects will be retired')
       return
     }
-    
+
     workflowOutput.retire(subjectIds, retireTarget)
+  }
+
+  doCreate () {
+    const workflowOutput = this.context.workflowOutput
+    const mlSelection = this.context.mlSelection
+    const selection = mlSelection.selection.toJSON() || []
+    const subjectIds = getUniqueSubjectIds(selection)
+
+    const createTarget = workflowOutput.createTarget.trim()
+
+    if (createTarget.length === 0) {
+      // TODO: better warnings
+      alert('Please specify a name for the new Subject Set')
+      return
+    }
+
+    workflowOutput.create(subjectIds, createTarget)
   }
 }
 

--- a/src/components/MLTaskManager/ProcessAndOutput.js
+++ b/src/components/MLTaskManager/ProcessAndOutput.js
@@ -138,7 +138,7 @@ class ProcessAndOutput extends React.Component {
 
         </fieldset>
 
-        <fieldset>
+        <fieldset style={{ visibility: 'hidden' }}>  /*TODO*/
           <legend>Create &amp; Move to New Subject Set</legend>
           <div>
             <span>Choose a name for your new Subject Set: &nbsp;</span>

--- a/src/config.js
+++ b/src/config.js
@@ -14,7 +14,7 @@ if (!env.match(/^(production|staging|development)$/)) {
 
 const config = {
   appRootUrl: localStorage.getItem('appRootUrl') || `${window.location.origin}${window.location.pathname}`,
-  proxyUrl: localStorage.getItem('proxyUrl') || 'https://subject-assistant-proxy.zooniverse.org',
+  proxyUrl: localStorage.getItem('proxyUrl') || process.env.PROXY_HOST || 'https://subject-assistant-proxy.zooniverse.org',
   hamletUrl: (env === 'production')
     ? 'https://hamlet-staging.zooniverse.org/'
     : 'https://hamlet-staging.zooniverse.org/',

--- a/src/store/AuthStore.js
+++ b/src/store/AuthStore.js
@@ -24,7 +24,7 @@ const AuthStore = types.model('AuthStore', {
       self.user = user
       
       root.userResources.reset()
-      if (user) root.userResources.fetch()
+      if (user) root.userResources.doFetch()
     } catch (err) {
       self.status = ASYNC_STATES.ERROR
     }

--- a/src/store/MLResultsStore.js
+++ b/src/store/MLResultsStore.js
@@ -19,7 +19,7 @@ const MLResultsStore = types.model('MLResultsStore', {
     self.data = {}
   },
 
-  fetch: flow(function * fetch (url) {
+  doFetch: flow(function * doFetch (url) {
     const root = getRoot(self)
     self.status = ASYNC_STATES.FETCHING
     self.statusMessage = undefined
@@ -36,7 +36,7 @@ const MLResultsStore = types.model('MLResultsStore', {
         .withCredentials()
         .then(res => {        
           if (res.ok) return JSON.parse(res.text)
-          throw new Error('ML Results Store couldn\'t fetch() data')
+          throw new Error('ML Results Store couldn\'t doFetch() data')
         })
 
       self.status = ASYNC_STATES.SUCCESS

--- a/src/store/MLResultsStore.js
+++ b/src/store/MLResultsStore.js
@@ -1,18 +1,17 @@
 import { flow, getRoot, types } from 'mobx-state-tree'
 import { ASYNC_STATES } from '@util'
 import config from '@config'
-import superagent from 'superagent'
 
 const DEMO_URL = `${config.appRootUrl}demo-data/detections.txt`
 
 const MLResultsStore = types.model('MLResultsStore', {
-  
+
   status: types.optional(types.string, ASYNC_STATES.IDLE),
   statusMessage: types.maybe(types.string),
   data: types.frozen({}),
-  
+
 }).actions(self => ({
-  
+
   reset () {
     self.status = ASYNC_STATES.IDLE
     self.statusMessage = undefined
@@ -25,33 +24,33 @@ const MLResultsStore = types.model('MLResultsStore', {
     self.statusMessage = undefined
 
     const proxiedUrl = `${config.proxyUrl}?url=${encodeURIComponent(url)}`
-    
+
     const _url = (!root.demoMode)
       ? proxiedUrl
       : DEMO_URL
 
     try {
-      const data = yield superagent
-        .get(_url)
-        .withCredentials()
-        .then(res => {        
-          if (res.ok) return JSON.parse(res.text)
-          throw new Error('ML Results Store couldn\'t doFetch() data')
-        })
+      const data = yield fetch(_url, {
+        method: 'GET',
+        credentials: 'include',
+      }).then(res => {
+        if (res.ok) return res.json()
+        throw new Error('ML Results Store couldn\'t doFetch() data')
+      })
 
       self.status = ASYNC_STATES.SUCCESS
       self.statusMessage = undefined
       self.data = data
 
       root.mlSelection.makeSelection()
-      
+
     } catch (err) {
       const message = err && err.toString() || undefined
       self.status = ASYNC_STATES.ERROR
       self.statusMessage = message
       console.error('[MLResultsStore] ', err)
     }
-    
+
   }),
 }))
 

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -7,14 +7,14 @@ const TASKS_ENDPOINT = '/task'
 const DEMO_URL = `${config.appRootUrl}demo-data/task.txt`
 
 const MLTaskStore = types.model('MLTaskStore', {
-  
+
   status: types.optional(types.string, ASYNC_STATES.IDLE),
   statusMessage: types.maybe(types.string),
   id: types.optional(types.string, ''),  // ID of the ML Task, specified by the user.
   data: types.frozen({}),  // Data related to the ML Task itself.
-  
+
   // Data from the results file, which is linked to from the ML Task, is stored in the MLResultsStore.
-  
+
 }).actions(self => ({
 
   reset () {
@@ -30,7 +30,7 @@ const MLTaskStore = types.model('MLTaskStore', {
     if (self.id !== val) self.reset()
     self.id = val
   },
-  
+
   fetch: flow(function * fetch () {
     const root = getRoot(self)
 
@@ -40,7 +40,7 @@ const MLTaskStore = types.model('MLTaskStore', {
 
     const serviceUrl = `${TASKS_ENDPOINT}/${self.id}`
     const proxiedUrl = `${config.proxyUrl}?url=${encodeURIComponent(serviceUrl)}&target=msml`
-    
+
     const url = (!root.demoMode)
       ? proxiedUrl
       : DEMO_URL
@@ -53,13 +53,13 @@ const MLTaskStore = types.model('MLTaskStore', {
           if (res.ok) return res.body || JSON.parse(res.text)  // The latter is for demo-data
           throw new Error('ML Task Store can\'t fetch() data')
         })
-      
+
       self.status = ASYNC_STATES.SUCCESS
       self.statusMessage = undefined
       self.data = data
-      
+
       if (data.Status && typeof(data.Status) === 'object') {
-        
+
         switch (data.Status.request_status) {
           case API_RESPONSE.REQUEST_STATUS.COMPLETED:
 
@@ -83,7 +83,7 @@ const MLTaskStore = types.model('MLTaskStore', {
       }
 
       throw new Error('ML Task encountered an unknown error.')
-      
+
     } catch (err) {
       const message = err && err.toString() || undefined
       self.status = ASYNC_STATES.ERROR

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -1,7 +1,6 @@
 import { flow, getRoot, types } from 'mobx-state-tree'
 import { ASYNC_STATES, API_RESPONSE } from '@util'
 import config from '@config'
-import superagent from 'superagent'
 
 const TASKS_ENDPOINT = '/task'
 const DEMO_URL = `${config.appRootUrl}demo-data/task.txt`
@@ -46,13 +45,13 @@ const MLTaskStore = types.model('MLTaskStore', {
       : DEMO_URL
 
     try {
-      const data = yield superagent
-        .get(url)
-        .withCredentials()
-        .then(res => {
-          if (res.ok) return res.body || JSON.parse(res.text)  // The latter is for demo-data
-          throw new Error('ML Task Store can\'t doFetch() data')
-        })
+      const data = yield fetch(url, {
+        method: 'GET',
+        credentials: 'include',
+      }).then(res => {
+        if (res.ok) return res.json() || JSON.parse(res.text)  // The latter is for demo-data
+        throw new Error('ML Task Store can\'t doFetch() data')
+      })
 
       self.status = ASYNC_STATES.SUCCESS
       self.statusMessage = undefined

--- a/src/store/MLTaskStore.js
+++ b/src/store/MLTaskStore.js
@@ -31,7 +31,7 @@ const MLTaskStore = types.model('MLTaskStore', {
     self.id = val
   },
 
-  fetch: flow(function * fetch () {
+  doFetch: flow(function * doFetch () {
     const root = getRoot(self)
 
     self.reset()
@@ -51,7 +51,7 @@ const MLTaskStore = types.model('MLTaskStore', {
         .withCredentials()
         .then(res => {
           if (res.ok) return res.body || JSON.parse(res.text)  // The latter is for demo-data
-          throw new Error('ML Task Store can\'t fetch() data')
+          throw new Error('ML Task Store can\'t doFetch() data')
         })
 
       self.status = ASYNC_STATES.SUCCESS
@@ -65,7 +65,7 @@ const MLTaskStore = types.model('MLTaskStore', {
 
             const url = data.Status.message && data.Status.message.output_file_urls && data.Status.message.output_file_urls.detections
             if (!url) throw new Error('ML Task did not have any valid results.')
-            root.mlResults.fetch(url)
+            root.mlResults.doFetch(url)
             return
 
           case API_RESPONSE.REQUEST_STATUS.RUNNING:

--- a/src/store/UserResourcesStore.js
+++ b/src/store/UserResourcesStore.js
@@ -2,7 +2,6 @@ import { flow, getRoot, types } from 'mobx-state-tree'
 import { ASYNC_STATES } from '@util'
 import config from '@config'
 import apiClient from 'panoptes-client'
-import superagent from 'superagent'
 
 const UserResourcesStore = types.model('UserResourcesStore', {
 

--- a/src/store/UserResourcesStore.js
+++ b/src/store/UserResourcesStore.js
@@ -29,7 +29,7 @@ const UserResourcesStore = types.model('UserResourcesStore', {
     root.workflowOutput.resetTargets()
   },
 
-  fetch: flow(function * fetch (url) {
+  doFetch: flow(function * doFetch (url) {
     const root = getRoot(self)
 
     try {

--- a/src/store/WorkflowOutputStore.js
+++ b/src/store/WorkflowOutputStore.js
@@ -5,44 +5,51 @@ import apiClient from 'panoptes-client'
 import superagent from 'superagent'
 
 const WorkflowOutputStore = types.model('WorkflowOutputStore', {
-  operation: types.optional(types.enumeration('operation', ['', 'move', 'retire']), ''),
+  operation: types.optional(types.enumeration('operation', ['', 'move', 'retire', 'create']), ''),
   status: types.optional(types.string, ASYNC_STATES.IDLE),
   statusMessage: types.maybe(types.string),
-  
+
   moveTarget: types.optional(types.string, ''),
   retireTarget: types.optional(types.string, ''),
-  
+  createTarget: types.optional(types.string, ''),
+
 }).actions(self => ({
-    
+
   reset () {
     self.operation = ''
     self.status = ASYNC_STATES.IDLE
     self.statusMessage = undefined
-    
+
     self.moveTarget = ''
     self.retireTarget = ''
+    self.createTarget = ''
   },
-  
+
   resetTargets () {
     self.moveTarget = ''
     self.retireTarget = ''
+    self.createTarget = ''
   },
-  
+
   setMoveTarget (val) {
     self.moveTarget = val
   },
-  
+
   setRetireTarget (val) {
     self.retireTarget = val
+  },
+
+  setCreateTarget (val) {
+    self.createTarget = val
   },
 
   move: flow(function * moveToSubjectSet (subjectIds, subjectSetId) {
     self.operation = 'move'
     self.status = ASYNC_STATES.SENDING
     self.statusMessage = undefined
-    
+
     const url = `${apiClient.root}/subject_sets/${subjectSetId}/links/subjects`
-    
+
     try {
       const data = yield superagent
         .post(url)
@@ -54,7 +61,7 @@ const WorkflowOutputStore = types.model('WorkflowOutputStore', {
           subjects: subjectIds,
         })
         .then(res => {
-          if (res.ok) return res.body          
+          if (res.ok) return res.body
           throw new Error()
         })
         .catch(err => {
@@ -69,23 +76,23 @@ const WorkflowOutputStore = types.model('WorkflowOutputStore', {
 
       self.status = ASYNC_STATES.SUCCESS
       self.statusMessage = undefined
-      
+
     } catch (err) {
       const message = err && err.toString() || undefined
       self.status = ASYNC_STATES.ERROR
       self.statusMessage = message
       console.error('[WorkflowOutputStore] ', err)
     }
-    
+
   }),
-  
+
   retire: flow(function * retireInWorkflow (subjectIds, workflowId) {
     self.operation = 'retire'
     self.status = ASYNC_STATES.SENDING
     self.statusMessage = undefined
-    
+
     const url = `${apiClient.root}/workflows/${workflowId}/retired_subjects`
-    
+
     try {
       yield superagent
         .post(url)
@@ -98,7 +105,7 @@ const WorkflowOutputStore = types.model('WorkflowOutputStore', {
           retirement_reason: 'other',
         })
         .then(res => {
-           if (res.ok) return res.body          
+           if (res.ok) return res.body
            throw new Error()
         })
         .catch(err => {
@@ -108,7 +115,7 @@ const WorkflowOutputStore = types.model('WorkflowOutputStore', {
 
       self.status = ASYNC_STATES.SUCCESS
       self.statusMessage = undefined
-      
+
     } catch (err) {
       const message = err && err.toString() || undefined
       self.status = ASYNC_STATES.ERROR
@@ -116,7 +123,15 @@ const WorkflowOutputStore = types.model('WorkflowOutputStore', {
       console.error('[WorkflowOutputStore] ', err)
     }
   }),
-  
+
+  create: flow(function * createAndMoveToSubjectSet (subjectIds, subjectSetName) {
+    self.operation = 'create'
+    self.status = ASYNC_STATES.SENDING
+    self.statusMessage = undefined
+
+    console.log('+++ ', subjectSetName)
+  }),
+
 }))
 
 export { WorkflowOutputStore }

--- a/src/store/WorkflowOutputStore.js
+++ b/src/store/WorkflowOutputStore.js
@@ -129,8 +129,6 @@ const WorkflowOutputStore = types.model('WorkflowOutputStore', {
     self.status = ASYNC_STATES.SENDING
     self.statusMessage = undefined
 
-    console.log('+++ ', subjectSetName)
-
     const url = `${apiClient.root}/subject_sets`
 
     try {
@@ -155,6 +153,7 @@ const WorkflowOutputStore = types.model('WorkflowOutputStore', {
         throw new Error('ML Results Store couldn\'t create a new Subject Set')
       })
 
+      alert('DEBUG: a new Subject Set was created on Project 16927. This is a work in progress.')
       console.log('+++ data: ', data)
 
     } catch (err) {

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -56,6 +56,6 @@ export function statusIcon (status) {
     case ASYNC_STATES.SENDING:
       return <i className="material-icons">sync</i>
   }
-  
+
   return null;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,9 +10,9 @@ module.exports = {
     filename: "[name].js",
     path: path.resolve(__dirname, 'app'),
   },
-  mode: "development",
+  mode: "none",
   resolve: {
-    alias: {  // Allows absolute paths in import statements, so we can `import Example from '@store/Example'` instead of `import Example from '../../src/store/Example'` 
+    alias: {  // Allows absolute paths in import statements, so we can `import Example from '@store/Example'` instead of `import Example from '../../src/store/Example'`
       '@util': path.resolve(__dirname, 'src/util/'),
       '@store': path.resolve(__dirname, 'src/store/'),
       '@config': path.resolve(__dirname, 'src/config/'),
@@ -27,6 +27,7 @@ module.exports = {
       PANOPTES_ENV: 'staging',
       PANOPTES_API_HOST: false,
       PANOPTES_API_APPLICATION: false,
+      PROXY_HOST: false,
       TALK_HOST: false,
       SUGAR_HOST: false,
       STAT_HOST: false,
@@ -90,7 +91,7 @@ module.exports = {
       'localhost',
       '.zooniverse.org'
     ],
-    //contentBase: path.join(__dirname, 'app'),  // Previously, 
+    //contentBase: path.join(__dirname, 'app'),  // Previously,
     contentBase: path.join(__dirname, '/'),  // Serve from the root, so we mimic how content is served from the root at https://subject-assistant.zooniverse.org/
     host: process.env.HOST || 'localhost',
     https: true,


### PR DESCRIPTION
## PR Overview

This PR collects a bunch of small, random updates.

- README updated. If import is that local development must now be done via `localhost`, not the standard Zooniverse alias of `local.zooniverse.org`
- Local development now uses **production,** since the closely associated hamlet-staging runs on production as well.
  - External change: Zooniverse oAuth app for Subject Assistant now allows localhost as a valid return URL.
- The proxy URL can now either be set via the in-app config, or via the `PROXY_HOST` environment variable.
- Several (but not all) `superagent` calls have been replaced with the modern `fetch` API
  - Work in progress: need to update "move" and "retire" actions with fetch API. 
- WORK IN PROGRESS: the basics for 'Create & Move to Subject Set' have been set up
  - We can create a new Subject Set (via the fetch API), but we only for a specific hardcoded project. 
  - _I realise now that we need an option to filter workflows/subject sets/etc via **project**. This should affect 'move', 'retire', and 'create & move' actions._