### PR TITLE
Proxy to zoo hosted camera traps api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,9 @@ services:
     ports:
       - "3666:3666"
     environment:
+      - URL_FOR_MSML=http://otter.southcentralus.cloudapp.azure.com:6001/v4/camera-trap/detection-batch
+      - CAMERA_TRAPS_API_SERVICE_HOST=10.0.244.99
+      - CAMERA_TRAPS_API_SERVICE_PATH=/v4/camera-trap/detection-batch
       - ORIGINS=${ORIGINS}
       - TARGETS=${TARGETS}
       - REVISION=fakerevision123

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -26,6 +26,8 @@ spec:
           ports:
             - containerPort: 80
           env:
+            - name: CAMERA_TRAPS_API_SERVICE_PATH
+              value: /v4/camera-trap/detection-batch
             - name: ORIGINS
               valueFrom:
                 secretKeyRef:

--- a/server/proxy-server.js
+++ b/server/proxy-server.js
@@ -4,10 +4,29 @@ require('dotenv').config()
 
 const server = express()
 
+function targetsConfig() {
+  let targets = process.env.TARGETS || 'http://example.com;https://www.zooniverse.org/'
+  // append the Zooniverse hosted service HOST if the env var is set, else use the defaults above
+  if (process.env.CAMERA_TRAPS_API_SERVICE_HOST) {
+    targets = `http://${process.env.CAMERA_TRAPS_API_SERVICE_HOST};${targets}`
+  }
+  return targets
+}
+
+function urlForMsml() {
+  // Microsofot Machine Learning Camera Traps URL
+  let url = process.env.URL_FOR_MSML
+  // use Zooniverse hosted service URL if the env var is set, else use the default above
+  if (process.env.CAMERA_TRAPS_API_SERVICE_HOST) {
+    url = `http://${process.env.CAMERA_TRAPS_API_SERVICE_HOST}${process.env.CAMERA_TRAPS_API_SERVICE_PATH}`
+  }
+  return url
+}
+
 const config = {
   origins: process.env.ORIGINS || 'https://localhost:3000;https://local.zooniverse.org:3000',
-  targets: process.env.TARGETS || 'http://example.com;https://www.zooniverse.org/',
-  url_for_msml: process.env.URL_FOR_MSML || '',  // Microsofot Machine Learning
+  targets: targetsConfig(),
+  url_for_msml: urlForMsml(),
   port: process.env.PORT || 3666,
   revision: process.env.REVISION || '',
 }
@@ -61,7 +80,7 @@ function proxyGet (req, res) {
         .json({'error': 'Target URL is not in the whitelist'});
 
     } else {
-      
+
       // We need to use fetch instead of superagent because the latter can't
       // handle streaming data (content-type: application/octent-stream)
       fetch(url)
@@ -96,4 +115,5 @@ server.listen(config.port, (err) => {
   console.log(`Proxy Server running at port ${config.port}`)
   console.log(`Acceptable origins: ${config.origins.split(';')}`)
   console.log(`Acceptable targets: ${config.targets.split(';')}`)
+  console.log(`MS ML URL: ${config.url_for_msml}`)
 })


### PR DESCRIPTION
This PR modifies the way our system configs are setup. Specifically to allow our proxy to automatically determine the zooniverse hosted k8s deployed MS camera traps API deployment (via auto ENV vars)

this will allow our proxy to auto config when these env vars are in place and safely fallback to existing config setup if not present